### PR TITLE
Feature/tem cmd in threads

### DIFF
--- a/jungfrau_gui/ui_components/tem_controls/task/task_manager.py
+++ b/jungfrau_gui/ui_components/tem_controls/task/task_manager.py
@@ -358,7 +358,7 @@ class ControlWorker(QObject):
             # logging.warning("TEM server is OFF")
             # time.sleep(0.12)
             logging.warning("GUI diconnected from TEM")
-            self.task_thread.quit()
+            # self.task_thread.quit() # TODO Raises error: Internal C++ object (PySide6.QtCore.QThread) already deleted.
         except Exception as e:
             logging.error(f'Shutdown of Task Manager triggered error: {e}')
             pass

--- a/jungfrau_gui/ui_components/tem_controls/task/task_manager.py
+++ b/jungfrau_gui/ui_components/tem_controls/task/task_manager.py
@@ -250,13 +250,17 @@ class ControlWorker(QObject):
     def send_to_tem(self, message):
         logging.debug(f'Sending {message} to TEM...')
         if message == "#info":
-            results = self.get_state()
-            self.trigger_tem_update.emit(results)
+            # results = self.get_state()
+            # self.trigger_tem_update.emit(results)
+            threading.Thread(target=lambda: self.trigger_tem_update.emit(self.get_state())).start()
+
         elif message == "#more":
-            results = self.get_state_detailed()
-            self.trigger_tem_update.emit(results)
+            # results = self.get_state_detailed()
+            # self.trigger_tem_update.emit(results)
+            threading.Thread(target=lambda: self.trigger_tem_update.emit(self.get_state_detailed())).start()
+            
         else:
-            logging.debug("Just passing through")
+            logging.error(f"{message} is not valid for ControlWorker::send_to_tem()")
             pass
 
     def get_state(self):
@@ -313,8 +317,10 @@ class ControlWorker(QObject):
             return result if result is not None else "No result returned"
         except AttributeError:
             logging.error(f"Error: The method '{method_name}' does not exist.")
+            return None
         except Exception as e:
             logging.error(f"Error: {e}")
+            return None
 
     def stop_task(self):
         if self.task:

--- a/jungfrau_gui/ui_components/tem_controls/tem_action.py
+++ b/jungfrau_gui/ui_components/tem_controls/tem_action.py
@@ -53,16 +53,34 @@ class TEMAction(QObject):
         # self.control.tem_socket_status.connect(self.on_sockstatus_change)
         self.control.updated.connect(self.on_tem_update)
         
-        self.tem_stagectrl.movex10ump.clicked.connect(lambda: self.control.client.SetXRel(10000))
-        self.tem_stagectrl.movex10umn.clicked.connect(lambda: self.control.client.SetXRel(-10000))
+        # Move X positive 10 micrometers
+        # self.tem_stagectrl.movex10ump.clicked.connect(lambda: self.control.client.SetXRel(10000))
+        self.tem_stagectrl.movex10ump.clicked.connect(
+            lambda: threading.Thread(target=self.control.client.SetXRel, args=(10000,)).start())
+        
+        # Move X negative 10 micrometers
+        # self.tem_stagectrl.movex10umn.clicked.connect(lambda: self.control.client.SetXRel(-10000))
+        self.tem_stagectrl.movex10umn.clicked.connect(
+            lambda: threading.Thread(target=self.control.client.SetXRel, args=(-10000,)).start())
 
+        # Move TX positive 10 degrees
+        # self.tem_stagectrl.move10degp.clicked.connect(
+        #             lambda: self.control.client.SetTXRel(10))
         self.tem_stagectrl.move10degp.clicked.connect(
-                    lambda: self.control.client.SetTXRel(10))
-        self.tem_stagectrl.move10degn.clicked.connect(
-                    lambda: self.control.client.SetTXRel(-10))        
-        self.tem_stagectrl.move0deg.clicked.connect(
-                    lambda: self.control.client.SetTiltXAngle(0))
+            lambda: threading.Thread(target=self.control.client.SetTXRel, args=(10,)).start())
 
+        # Move TX negative 10 degrees
+        # self.tem_stagectrl.move10degn.clicked.connect(
+        #             lambda: self.control.client.SetTXRel(-10))        
+        self.tem_stagectrl.move10degn.clicked.connect(
+            lambda: threading.Thread(target=self.control.client.SetTXRel, args=(-10,)).start())
+
+        # Set Tilt X Angle to 0 degrees
+        # self.tem_stagectrl.move0deg.clicked.connect(
+        #             lambda: self.control.client.SetTiltXAngle(0))
+        self.tem_stagectrl.move0deg.clicked.connect(
+            lambda: threading.Thread(target=self.control.client.SetTiltXAngle, args=(0,)).start())
+        
     def set_configuration(self):
         self.file_operations.outPath_input.setText(self.cfg.data_dir.as_posix())
         self.file_operations.tiff_path.setText(self.cfg.data_dir.as_posix() + '/')


### PR DESCRIPTION
-Added threading to prevent freezes in case user wants asynchronous and recurrent updates on the TEM status while operating.
-Running fast movement commands concurrently, while updating GUI with TEM status, shows relative angle movements [```SetTXRel```] commands are not asynchronous, unlike  ```SetTiltXAngle``` for absolute angle definition who are...

-> This is what happens when you run SetTXRel(10) and asynchronously check TEM status:
```
Exception in thread Thread-50 (SetTXRel):
Traceback (most recent call last):
  File "/afs/psi.ch/user/f/ferjao_k/local_home/sw/simple-tem/simple_tem/TEMClient.py", line 36, in _send_message
    reply = socket.recv_multipart()
            ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ferjao_k/sw/miniforge3/envs/py/lib/python3.12/site-packages/zmq/sugar/socket.py", line 802, in recv_multipart
    parts = [self.recv(flags, copy=copy, track=track)]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "_zmq.py", line 1156, in zmq.backend.cython._zmq.Socket.recv
  File "_zmq.py", line 1191, in zmq.backend.cython._zmq.Socket.recv
  File "_zmq.py", line 1283, in zmq.backend.cython._zmq._recv_copy
  File "_zmq.py", line 1278, in zmq.backend.cython._zmq._recv_copy
  File "_zmq.py", line 171, in zmq.backend.cython._zmq._check_rc
zmq.error.Again: Resource temporarily unavailable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ferjao_k/sw/miniforge3/envs/py/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
  File "/home/ferjao_k/sw/miniforge3/envs/py/lib/python3.12/threading.py", line 1012, in run
    self._target(*self._args, **self._kwargs)
  File "/afs/psi.ch/user/f/ferjao_k/local_home/sw/simple-tem/simple_tem/TEMClient.py", line 185, in SetTXRel
    self._send_message("SetTXRel", val)
  File "/afs/psi.ch/user/f/ferjao_k/local_home/sw/simple-tem/simple_tem/TEMClient.py", line 43, in _send_message
    raise TimeoutError(f"Timeout while waiting for reply from {self.host}:{self.port}")
TimeoutError: Timeout while waiting for reply from localhost:3535
```
*/The command actually goes through but seems to raise a Timeout error on the TEMCleint's end.
*/GUI does not freeze and relays the error on the console... and TEM controls (re)become available once the rotation has been operated