### PR TITLE
Release v2025.02.10 fix stop record

### DIFF
--- a/USER_MANUAL/Usermanual.html
+++ b/USER_MANUAL/Usermanual.html
@@ -95,7 +95,7 @@
 </header>
 <h1 id="new-receiver-and-viewer-of-jungfrau-for-ed-ccsa-uniwien">New
 Receiver and Viewer of JUNGFRAU for ED, CCSA-UniWien</h1>
-<p>This document was updated on 6 Feb 2025<br />
+<p>This document was updated on 13 Feb 2025<br />
 <strong>When you encounter bug-like behaviors, please check <a
 href="#Known-bugs">known bugs</a>.</strong></p>
 <h2 id="table-of-contents">Table of Contents</h2>
@@ -259,12 +259,6 @@ spot shape (non-TEM mode only, useful for manual focusing).</li>
 <li><code>Magnification</code>, <code>Distance</code>: Displays the
 magnification and distance values (TEM mode only). <code>scale</code>
 checkbox displays the scale bar (1 um) or the ring (1 A).</li>
-<li><code>Accumulate in TIFF</code>: Saves a TIFF snapshot to the
-specified data path (<strong><a href="#Known-bugs">not tested in
-jfj-version</a></strong>).</li>
-<li><code>Write Stream in H5</code>: Saves an HDF movie to the specified
-data path (<strong><a href="#Known-bugs">not tested in
-jfj-version</a></strong>).</li>
 </ul>
 <h3 id="summing-receiver-controls"><a
 href="../jungfrau_gui/screenshot/ver_13Dec2024.png">Summing Receiver
@@ -303,9 +297,9 @@ allows to save the TEM status in a .log file. (<a href="#Known-bugs">not
 working correctly</a>)</li>
 <li><code>Click-on-Centering</code>: Activates stage XY-control by
 clicking on the imageat the pint of interest.</li>
-<li><code>Beam Gaussian Fit</code>: Fits a gaussian to the direct beam
-within the ROI (A preliminary way to get the beam center info to add to
-the metadata)
+<li><code>Gaussian Fit</code>: Fits a gaussian to the direct beam within
+the ROI (A preliminary way to get the beam center info to add to the
+metadata)
 <ul>
 <li><code>Beam center (px)</code>: Displays the position
 (X_center,Y_center) of the center of the fitted gaussian<br />
@@ -326,8 +320,6 @@ The beam is unblanked during rotation and blanked when rotation ends.
 <ul>
 <li><code>with Writer</code>: Synchronizes the HDF writer with
 rotation.</li>
-<li><code>JFJ</code>: Saves data in JFJ-server (noether). Otherwise the
-data will be saved locally (hodgkin).</li>
 <li><code>Auto reset</code>: Resets the tilt to 0 degrees after
 rotation.</li>
 </ul></li>
@@ -365,31 +357,7 @@ collected (e.g., UniVie, External, IP).</li>
 <li><code>Base Data Directory</code>: Specifies the root directory for
 data saving.</li>
 </ul>
-<p><strong>Note:</strong> The [Get] buttons were coded for debugging
-purposes. They will be removed for the stable version.</p>
-<p><strong>Important:</strong> TIFF-Writer and HDF5-Writer have not been
-tested with JFJ. Use <a
-href="#summing-receiver-controls"><code>Collect</code></a> in
-Visualization Panel instead.</p>
-<h4 id="tiff-writer">TIFF Writer</h4>
-<ul>
-<li><code>Tiff File Name</code>: Area to define the name of the TIFF
-file and its index. It contains:<br />
-<small>
-<ul>
-<li>First line-edit is read-only and displays the folder where TIFF
-files are saved.</li>
-<li>Second line-edit is modifiable (ASCII characters and underscores
-only) and is meant for the file name.</li>
-<li>Spinbox is modifiable, is incremented after each writing and
-represents the index of the written TIFF.</li>
-</ul>
-</small></li>
-<li><code>index</code>: Set the file index for the TIFF file.</li>
-<li><code>Accumulate in TIFF</code>: Accumulates a specified number of
-frames in the TIFF file.</li>
-</ul>
-<h4 id="hdf5-writer">HDF5 Writer</h4>
+<h4 id="hdf5-output">HDF5 output</h4>
 <ul>
 <li><code>HDF5 Tag</code>*: Enter the file prefix (ASCII characters and
 underscores only).</li>
@@ -408,55 +376,76 @@ uploaded to the data base.</p>
 <li>Confirm the data output path on the <code>H5 Output Path</code>
 line-edit.</li>
 <li>Modify the stage rotation speed and end angle.</li>
-<li>Check the <code>with Writer</code> and <code>JFJ</code> boxes.</li>
+<li>Check the <code>with Writer</code> box.</li>
 <li>Click <code>Rotation</code> to start the rotation and
 recording.</li>
 <li>Continue until the end angle is reached or interrupted.</li>
 <li>Take an HDF movie if needed (e.g. crystal picture).</li>
 </ol>
 <h2 id="data-processing-notes">Data-processing notes</h2>
-<ul>
-<li><strong>XDS</strong>:
-<ul>
-<li><a
+<p>updated on 19 Jan 2025 - Data loading - <strong>XDS</strong>: - <a
 href="https://github.com/epoc-ed/epoc-utils/commit/2198487645fbb5390e2f629b570ac0dbf18db268">Version
 before 20.Aug.2024</a> <a
 href="https://github.com/epoc-ed/DataProcessing/tree/main/XDS/neggia">The
 plugin derived from Neggia</a> requires <code>_master.h5</code> in the
 filename. Create a symbolic link:
-<code>ln -s [full-path-of-hdffile] linked_master.h5</code></li>
-<li><a
+<code>ln -s [full-path-of-hdffile] linked_master.h5</code> - <a
 href="https://github.com/epoc-ed/GUI/releases/tag/v2024.10.10">Version
 before 10.Oct.2024</a> Data stored with float32 format. <a
 href="https://github.com/epoc-ed/DataProcessing/tree/main/XDS/neggia">Neggia-derived
 plugin</a> can work. <a
 href="https://github.com/epoc-ed/xdslib_epoc-jungfrau/tree/master">Another
-plugin</a> can not.</li>
-<li><a
+plugin</a> can not. - <a
 href="https://github.com/epoc-ed/GUI/releases/tag/v2024.10.10">Version
 after 10.Oct.2024</a> Data stored with int32 format and compressed. <a
 href="https://github.com/epoc-ed/xdslib_epoc-jungfrau/tree/master">Another
 plugin</a> can work. <a
 href="https://github.com/epoc-ed/DataProcessing/tree/main/XDS/neggia">Neggia-derived
-plugin</a> can not.</li>
-<li>Version after XX.Nov.2024 (JFJ installation) Data stored with int32
-format and linked with master.h5. <a
+plugin</a> can not. - Version after XX.Nov.2024 (JFJ installation) Data
+stored with int32 format and linked with master.h5. <a
 href="https://github.com/dectris/neggia/"><strong>The original
-Neggia-plugin</strong></a> can process the data.</li>
-</ul></li>
-<li><strong>DIALS</strong>: Install the <a
-href="https://github.com/epoc-ed/DataProcessing/blob/main/DIALS/format/FormatHDFJungfrauVIE02.py">updated
-Format Class</a> to read the HDF file directly:<br />
-<code>dials.import [filename.h5] slow_fast_beam_center=257,515 distance=660</code></li>
+Neggia-plugin</strong></a> can process the data.</p>
+<pre><code>- **DIALS**: Install the [updated Format Class for JF1M](https://github.com/epoc-ed/DataProcessing/blob/main/DIALS/format/FormatHDFJungfrau1MJFJVIE01.py) to read the HDF file directly:\
+   ``` dials.import [filename.h5] slow_fast_beam_center=532,515```</code></pre>
+<ul>
+<li>Script-based launching<br />
+<strong>This procedure is still under testing! Please try it
+carefully.<br />
+To run for the datasets recorded with the previous version of GUI, some
+parameters in the generated files (oscillation, calibrated camera
+length, etc.) need to be modified manually.</strong></li>
 </ul>
+<ol type="1">
+<li>Copy <a
+href="../jungfrau_gui/metadata_uploader/metadata_update_server.py">metadata_update_server.py</a>
+and <a
+href="../jungfrau_gui/metadata_uploader/jf1m_reprocess.py">jf1m_reprocess.py</a>
+to your local directory path in the processing-server (noether)</li>
+<li>(Option) Setup to launch DIALS
+<code>source [dials_installation_path]/dials-v3-22-1/dials_env.sh</code></li>
+<li>Run jf1m_reprocess.py to <strong>generate XDS.INP</strong> and
+<strong>(Optional) run DIALS with default parameters</strong> at your
+working directory with python or <em>dxtbx.python</em>
+<code>(dxtbx.)python jf1m_reprocess.py [full-path-of-xxx_master.h5] [full-path-of-template_directory_path]/XDS-JF1M_JFJ_2024-12-10.INP</code>
+*<em>Expected directory structure:</em></li>
+</ol>
+<pre><code>.
+|--XDS
+|    └--XDS.INP
+└--DIALS
+     |--dials.import.log
+     |--imported.expt
+     |--dials.find_spots.log
+     |--strong.refl
+     :</code></pre>
 <h2 id="troubleshooting">Troubleshooting</h2>
 <ul>
 <li><p><strong>PowerShell console not responding after disconnecting
 from GUI</strong>: Open another PowerShell console and kill the python
 process:</p>
-<div class="sourceCode" id="cb11"><pre
-class="sourceCode bash"><code class="sourceCode bash"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="ex">Get-Process</span> python</span>
-<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a><span class="bu">kill</span> <span class="pp">[</span><span class="ss">pid</span><span class="pp">]</span></span></code></pre></div></li>
+<div class="sourceCode" id="cb13"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="ex">Get-Process</span> python</span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a><span class="bu">kill</span> <span class="pp">[</span><span class="ss">pid</span><span class="pp">]</span></span></code></pre></div></li>
 <li><p><strong>TEM-control button delay</strong>: There may be a few
 seconds of delay when responding, especially the first time. Please
 wait.</p></li>
@@ -464,12 +453,8 @@ wait.</p></li>
 <h3 id="known-bugs">Known bugs</h3>
 <p>updated on 13 Dec 2024 - Autocontrast does not work correctly after
 installation of JF-1M. Modify contrast manually or use fixed-contrast
-buttons. - Tiff- and HDF- writers have not been tested after
-installation of JFJ. Use <a
-href="#summing-receiver-controls"><code>Collect</code> and
-<code>Cancel</code></a> in Visualization Panel instead. - Recording of
-TEM-related values does not correctly output a file. Currently this
-function is disabled.</p>
+buttons. - Recording of TEM-related values does not correctly output a
+file. Currently this function is disabled.</p>
 <h3 id="launching-previous-system">Launching previous system</h3>
 <ul>
 <li>Usage of previous rotation commands/scripts under PyJEM3.8
@@ -479,21 +464,21 @@ environment</li>
 <li><p>Open a Miniconda PowerShell Prompt (Anaconda submenu) from the
 Windows Start Menu.</p></li>
 <li><p>activate ‘vjem38’ virtual environment</p>
-<div class="sourceCode" id="cb12"><pre
-class="sourceCode bash"><code class="sourceCode bash"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="ex">conda</span> activate vjem38</span></code></pre></div></li>
+<div class="sourceCode" id="cb14"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="ex">conda</span> activate vjem38</span></code></pre></div></li>
 <li><p>Navigate to <code>C:\ProgramData\xxxxxx</code></p></li>
 <li><p>Start interactive python, and load PyJEM module and use the
 commands:<br />
 </p>
-<div class="sourceCode" id="cb13"><pre
-class="sourceCode bash"><code class="sourceCode bash"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="ex">python</span></span>
-<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a><span class="op">&gt;&gt;&gt;</span> from <span class="ex">PyJEM</span> import TEM3</span>
-<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a><span class="op">&gt;&gt;&gt;</span> stage <span class="ex">=</span> TEM3.Stage3<span class="er">(</span><span class="kw">)</span></span>
-<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a><span class="op">&gt;&gt;&gt;</span> stage.Setf1OverRateTxNum<span class="kw">(</span><span class="ex">1</span><span class="kw">)</span></span>
-<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a><span class="op">&gt;&gt;&gt;</span> stage.SetTiltXAngle<span class="kw">(</span><span class="ex">60</span><span class="kw">)</span></span></code></pre></div></li>
+<div class="sourceCode" id="cb15"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="ex">python</span></span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a><span class="op">&gt;&gt;&gt;</span> from <span class="ex">PyJEM</span> import TEM3</span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a><span class="op">&gt;&gt;&gt;</span> stage <span class="ex">=</span> TEM3.Stage3<span class="er">(</span><span class="kw">)</span></span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a><span class="op">&gt;&gt;&gt;</span> stage.Setf1OverRateTxNum<span class="kw">(</span><span class="ex">1</span><span class="kw">)</span></span>
+<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a><span class="op">&gt;&gt;&gt;</span> stage.SetTiltXAngle<span class="kw">(</span><span class="ex">60</span><span class="kw">)</span></span></code></pre></div></li>
 <li><p>Or just call a python script</p>
-<div class="sourceCode" id="cb14"><pre
-class="sourceCode bash"><code class="sourceCode bash"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="ex">python</span> rotational_devel.py</span></code></pre></div></li>
+<div class="sourceCode" id="cb16"><pre
+class="sourceCode bash"><code class="sourceCode bash"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="ex">python</span> rotational_devel.py</span></code></pre></div></li>
 </ol>
 </body>
 </html>

--- a/USER_MANUAL/Usermanual.md
+++ b/USER_MANUAL/Usermanual.md
@@ -1,5 +1,5 @@
 # New Receiver and Viewer of JUNGFRAU for ED, CCSA-UniWien
-This document was updated on 6 Feb 2025\
+This document was updated on 13 Feb 2025\
 **When you encounter bug-like behaviors, please check [known bugs](#Known-bugs).**
 
 ## Table of Contents
@@ -127,8 +127,6 @@ This document was updated on 6 Feb 2025\
 - `Exit`: Exits the GUI.
 - `Beam Gaussian Fit`: Starts fitting the beam's elliptical spot shape (non-TEM mode only, useful for manual focusing).
 - `Magnification`, `Distance`: Displays the magnification and distance values (TEM mode only). `scale` checkbox displays the scale bar (1 um) or the ring (1 A).
-- `Accumulate in TIFF`: Saves a TIFF snapshot to the specified data path (**[not tested in jfj-version](#Known-bugs)**).
-- `Write Stream in H5`: Saves an HDF movie to the specified data path (**[not tested in jfj-version](#Known-bugs)**).
 
 ### [Summing Receiver Controls](../jungfrau_gui/screenshot/ver_13Dec2024.png)
 
@@ -148,7 +146,7 @@ This document was updated on 6 Feb 2025\
 - `Get TEM status`: Displays the TEM status in the terminal [with the option of writing status in .log file] \
     -`recording`: **(disabled)** When checked, allows to save the TEM status in a .log file. ([not working correctly](#Known-bugs))
 - `Click-on-Centering`: Activates stage XY-control by clicking on the imageat the pint of interest.
-- `Beam Gaussian Fit`: Fits a gaussian to the direct beam  within the ROI (A preliminary way to get the beam center info to add to the metadata)
+- `Gaussian Fit`: Fits a gaussian to the direct beam  within the ROI (A preliminary way to get the beam center info to add to the metadata)
     - `Beam center (px)`: Displays the position (X_center,Y_center) of the center of the fitted gaussian  
     - `Gaussian height`: Displays the peak of the gaussian (keV)
     - `Sigma x (px)`: Standard deviation in the major x-axis
@@ -157,7 +155,6 @@ This document was updated on 6 Feb 2025\
 - `Beam Autofocus`: **(Not ready for use)** Sweeps IL1 and ILstig values.
 - `Rotation`: Starts stage rotation to the target angle. The beam is unblanked during rotation and blanked when rotation ends.
     - `with Writer`: Synchronizes the HDF writer with rotation.
-    - `JFJ`: Saves data in JFJ-server (noether). Otherwise the data will be saved locally (hodgkin).
     - `Auto reset`: Resets the tilt to 0 degrees after rotation.
 - `Rotation Speed`: Adjusts rotation speed before starting the rotation. Also updates the `rotation_speed_idx` variable of the Configuration Manager in the data base.
 - `Stage Ctrl`: Moves the stage in specific direction. \*Rotations are not automatically quicken.
@@ -176,22 +173,7 @@ This document was updated on 6 Feb 2025\
 - `Project ID`*: Enter the project identifier.
 - `Base Data Directory`: Specifies the root directory for data saving.
 
-**Note:** The [Get] buttons were coded for debugging purposes. They will be removed for the stable version.
-
-**Important:** TIFF-Writer and HDF5-Writer have not been tested with JFJ. Use [`Collect`](#summing-receiver-controls) in Visualization Panel instead.
-
-#### TIFF Writer
-- `Tiff File Name`: Area to define the name of the TIFF file and its index. It contains:\
-   <small>
-   - First line-edit is read-only and displays the folder where TIFF files are saved.
-   - Second line-edit is modifiable (ASCII characters and underscores only) and is meant for the file name.
-   - Spinbox is modifiable, is incremented after each writing and represents the index of the written TIFF.
-
-   </small>
-- `index`: Set the file index for the TIFF file.
-- `Accumulate in TIFF`: Accumulates a specified number of frames in the TIFF file.
-
-#### HDF5 Writer
+#### HDF5 output
 - `HDF5 Tag`*: Enter the file prefix (ASCII characters and underscores only).
 - `index`*: Set the file index for the HDF5 file.
 - `H5 Output Path`: Read-only field showing the path where datasets are saved.
@@ -204,7 +186,7 @@ This document was updated on 6 Feb 2025\
 2. Blank the beam to avoid sample damage.
 3. Confirm the data output path on the `H5 Output Path` line-edit.
 4. Modify the stage rotation speed and end angle.
-5. Check the `with Writer` and `JFJ` boxes.
+5. Check the `with Writer` box.
 6. Click `Rotation` to start the rotation and recording.
 7. Continue until the end angle is reached or interrupted.
 8. Take an HDF movie if needed (e.g. crystal picture).
@@ -262,7 +244,6 @@ To run for the datasets recorded with the previous version of GUI, some paramete
 ### Known bugs
 updated on 13 Dec 2024
 - Autocontrast does not work correctly after installation of JF-1M. Modify contrast manually or use fixed-contrast buttons.
-- Tiff- and HDF- writers have not been tested after installation of JFJ. Use [`Collect` and `Cancel`](#summing-receiver-controls) in Visualization Panel instead.
 - Recording of TEM-related values does not correctly output a file. Currently this function is disabled.
 
 ### Launching previous system

--- a/jungfrau_gui/metadata_uploader/metadata_update_client.py
+++ b/jungfrau_gui/metadata_uploader/metadata_update_client.py
@@ -100,7 +100,10 @@ if __name__ == "__main__":
         tem_status = json.load(file)
 
     beamcenter = cfg.beam_center # Read from Redis DB
-    rotations_angles = [0.0, 0.0, 0.0, 0.0, 0.0] # Define a list with the correct format 
+    
+    # Example data for rotation at 10deg/s
+    rotations_angles = [[0.0, 0.0], [1.0, 10.0], [2.0, 19.95], [3.0, 30.12], [4.0, 40.2],[5.0, 50.05],[6.0, 60.0]]
+    
     jf_threshold = 5 
     #input("Enter to continue!")
 

--- a/jungfrau_gui/metadata_uploader/metadata_update_server.py
+++ b/jungfrau_gui/metadata_uploader/metadata_update_server.py
@@ -274,6 +274,9 @@ class Hdf5MetadataUpdater:
             except zmq.ZMQError as e:
                 logging.error(f"Error while receiving request: {e}")
                 # self.socket.send_string("Error updating metadata")
+            # except Exception as e:
+            #     logging.error(f"Error while receiving/processing request: {e}", exc_info=True)
+            #     break
     
     def stop(self):
         self.running = False

--- a/jungfrau_gui/ui_components/file_operations/file_operations.py
+++ b/jungfrau_gui/ui_components/file_operations/file_operations.py
@@ -334,14 +334,17 @@ class FileOperations(QGroupBox):
             if self.parent.tem_controls.tem_action.temConnector is not None: ## to be checked again
                 self.parent.tem_controls.tem_action.control.send_to_tem("#more", asynchronous = False)
                 logging.info(" ******************** Adding Info to H5 over Server...")
-                send_with_retries(self.metadata_notifier.notify_metadata_update, 
-                                    self.parent.visualization_panel.formatted_filename, 
-                                    self.parent.tem_controls.tem_action.control.tem_status, #self.control.tem_status, 
-                                    self.cfg.beam_center, 
-                                    None, # self.rotations_angles,
-                                    self.cfg.threshold,
-                                    retries=3, 
+                try:
+                    send_with_retries(self.metadata_notifier.notify_metadata_update, 
+                                        self.parent.visualization_panel.formatted_filename, 
+                                        self.parent.tem_controls.tem_action.control.tem_status, #self.control.tem_status, 
+                                        self.cfg.beam_center, 
+                                        None, # self.rotations_angles,
+                                        self.cfg.threshold,
+                                        retries=3, 
                                     delay=0.1) 
+                except Exception as e:
+                    logging.error(f"Metadata Update Error: {e}")
             logging.info(f'Snapshot duration end: {int(self.snapshot_spin.value())*1e-3} sec')
             self.tag_input.setText(self.pre_text) # reset the tag to value before snapshot
             self.update_measurement_tag()

--- a/jungfrau_gui/ui_components/file_operations/file_operations.py
+++ b/jungfrau_gui/ui_components/file_operations/file_operations.py
@@ -6,7 +6,7 @@ from PySide6.QtWidgets import (QGroupBox, QVBoxLayout, QHBoxLayout,
                                 QPushButton, QFileDialog, QCheckBox,
                                 QMessageBox, QGridLayout, QRadioButton)
 
-from .stream_writer import StreamWriter
+# from .stream_writer import StreamWriter
 from .frame_accumulator_mp import FrameAccumulator
 
 
@@ -26,8 +26,8 @@ import time
 
 class FileOperations(QGroupBox):
     trigger_update_h5_index_box = Signal()
-    start_H5_recording = Signal()
-    stop_H5_recording = Signal()
+    # start_H5_recording = Signal()
+    # stop_H5_recording = Signal()
     
     def __init__(self, parent):
         super().__init__()
@@ -197,7 +197,7 @@ class FileOperations(QGroupBox):
         #####################
         # HDF5 Writer Section
         #####################
-        HDF5_section_label = QLabel("HDF5 Writer", self)
+        HDF5_section_label = QLabel("HDF5 output", self)
         HDF5_section_label.setFont(font_big)
 
         section3.addWidget(HDF5_section_label)
@@ -247,16 +247,16 @@ class FileOperations(QGroupBox):
 
         section3.addLayout(output_folder_layout)
 
-        hdf5_writer_layout = QGridLayout()
+        """ hdf5_writer_layout = QGridLayout()
         self.streamWriter = None
         self.streamWriterButton = ToggleButton("Write Stream in H5", self)
         self.streamWriterButton.setEnabled(False)
         self.streamWriterButton.clicked.connect(self.toggle_hdf5Writer)
         self.start_H5_recording.connect(self.toggle_hdf5Writer_ON)
-        self.stop_H5_recording.connect(self.toggle_hdf5Writer_OFF)
+        self.stop_H5_recording.connect(self.toggle_hdf5Writer_OFF) """
         # self.xds_checkbox = QCheckBox("Prepare for XDS processing", self)
         # self.xds_checkbox.setChecked(True)
-        hdf5_writer_layout.addWidget(self.streamWriterButton, 0, 0, 1, 2)
+        """ hdf5_writer_layout.addWidget(self.streamWriterButton, 0, 0, 1, 2) """
         # hdf5_writer_layout.addWidget(self.xds_checkbox, 1, 0)
 
         # Change text color to orange when text is modified
@@ -268,7 +268,7 @@ class FileOperations(QGroupBox):
             else:
                 logging.error("Only QLineEdit and QSpinBox objects are supported!")
 
-        section3.addLayout(hdf5_writer_layout)
+        """ section3.addLayout(hdf5_writer_layout) """
         # section3.addStretch()
         # self.setLayout(section3)
 
@@ -327,7 +327,7 @@ class FileOperations(QGroupBox):
             self.snapshot_button.started = True
             self.parent.visualization_panel.send_command_to_jfjoch('collect')
             logging.info(f'Snapshot duration: {int(self.snapshot_spin.value())*1e-3} sec')
-            time.sleep(int(self.snapshot_spin.value())*1e-3)
+            time.sleep(int(self.snapshot_spin.value())*1e-3) # Blocking (Desired?)
             self.toggle_snapshot_btn()
         else:
             self.parent.visualization_panel.send_command_to_jfjoch('cancel')
@@ -401,7 +401,7 @@ class FileOperations(QGroupBox):
     #     if os.path.exists(path): 
     #         self.h5_folder_name = path
     
-    def toggle_hdf5Writer_ON(self):
+    """ def toggle_hdf5Writer_ON(self):
         if not self.streamWriterButton.started:
             self.toggle_hdf5Writer()
 
@@ -453,7 +453,7 @@ class FileOperations(QGroupBox):
             logging.info(f"Total number of frames written in H5 file:   {self.streamWriter.number_frames_witten}")
 
             self.streamWriterButton.setText("Write Stream in H5")
-            self.streamWriterButton.started = False
+            self.streamWriterButton.started = False """
     
     def text_modified(self, line_edit): 
         line_edit.setStyleSheet(f"QLineEdit {{ color: orange; background-color: {self.background_color}; }}")

--- a/jungfrau_gui/ui_components/file_operations/file_operations.py
+++ b/jungfrau_gui/ui_components/file_operations/file_operations.py
@@ -72,14 +72,14 @@ class FileOperations(QGroupBox):
 
         self.rb_experiment_class.buttonClicked.connect(self.update_experiment_class)
 
-        self.get_experiment_class = QPushButton("Get", self)
-        self.get_experiment_class.clicked.connect(lambda: print(f"Experiment Class: {self.cfg.experiment_class}"))
+        # self.get_experiment_class = QPushButton("Get", self)
+        # self.get_experiment_class.clicked.connect(lambda: print(f"Experiment Class: {self.cfg.experiment_class}"))
 
         redis_experiment_class_layout = QHBoxLayout()
         redis_experiment_class_layout.addWidget(self.experiment_class)
         for rb in self.rb_experiment_class.buttons():
             redis_experiment_class_layout.addWidget(rb, 1)
-        redis_experiment_class_layout.addWidget(self.get_experiment_class)
+        # redis_experiment_class_layout.addWidget(self.get_experiment_class)
 
         section3.addLayout(redis_experiment_class_layout)
         
@@ -91,15 +91,15 @@ class FileOperations(QGroupBox):
         self.redis_fields.append(self.userName_input)
         self.userName_input.setText(f'{self.cfg.PI_name}')
 
-        self.get_userName = QPushButton("Get", self)
-        self.get_userName.clicked.connect(lambda: print(f"PI Name: {self.cfg.PI_name}"))
+        # self.get_userName = QPushButton("Get", self)
+        # self.get_userName.clicked.connect(lambda: print(f"PI Name: {self.cfg.PI_name}"))
 
         self.userName_input.returnPressed.connect(self.update_userName)
 
         redis_UserName_layout = QHBoxLayout()
         redis_UserName_layout.addWidget(self.userName)
         redis_UserName_layout.addWidget(self.userName_input)
-        redis_UserName_layout.addWidget(self.get_userName)
+        # redis_UserName_layout.addWidget(self.get_userName)
 
         section3.addLayout(redis_UserName_layout)
 
@@ -111,15 +111,15 @@ class FileOperations(QGroupBox):
         self.redis_fields.append(self.projectID_input)
         self.projectID_input.setText(f'{self.cfg.project_id}')
 
-        self.get_projectID = QPushButton("Get", self)
-        self.get_projectID.clicked.connect(lambda: print(f"Project ID: {self.cfg.project_id}"))
+        # self.get_projectID = QPushButton("Get", self)
+        # self.get_projectID.clicked.connect(lambda: print(f"Project ID: {self.cfg.project_id}"))
 
         self.projectID_input.returnPressed.connect(self.update_projectID)
 
         redis_projectID_layout = QHBoxLayout()
         redis_projectID_layout.addWidget(self.projectID)
         redis_projectID_layout.addWidget(self.projectID_input)
-        redis_projectID_layout.addWidget(self.get_projectID)
+        # redis_projectID_layout.addWidget(self.get_projectID)
 
         section3.addLayout(redis_projectID_layout)
 
@@ -134,13 +134,13 @@ class FileOperations(QGroupBox):
         self.base_directory_input.setText(f'{self.cfg.base_data_dir}')
         self.base_directory_input.setReadOnly(True)
 
-        self.get_base_directory = QPushButton("Get", self)
-        self.get_base_directory.clicked.connect(lambda: print(f"Base Data Directory: {self.cfg.base_data_dir}"))
+        # self.get_base_directory = QPushButton("Get", self)
+        # self.get_base_directory.clicked.connect(lambda: print(f"Base Data Directory: {self.cfg.base_data_dir}"))
 
         redis_base_directory_layout = QHBoxLayout()
         redis_base_directory_layout.addWidget(self.base_directory)
         redis_base_directory_layout.addWidget(self.base_directory_input)
-        redis_base_directory_layout.addWidget(self.get_base_directory)
+        # redis_base_directory_layout.addWidget(self.get_base_directory)
 
         section3.addLayout(redis_base_directory_layout)
         

--- a/jungfrau_gui/ui_components/tem_controls/task/record_task.py
+++ b/jungfrau_gui/ui_components/tem_controls/task/record_task.py
@@ -19,7 +19,8 @@ from .... import globals
 class RecordTask(Task):
     reset_rotation_signal = Signal()
 
-    def __init__(self, control_worker, end_angle = 60, log_suffix = 'RotEDlog_test', writer_event=None, standard_h5_recording=False):
+    # def __init__(self, control_worker, end_angle = 60, log_suffix = 'RotEDlog_test', writer_event=None, standard_h5_recording=False):
+    def __init__(self, control_worker, end_angle = 60, log_suffix = 'RotEDlog_test', writer_event=None):
         super().__init__(control_worker, "Record")
         self.phi_dot = 0 # 10 deg/s
         self.control = control_worker
@@ -32,7 +33,7 @@ class RecordTask(Task):
         self.client = TEMClient(globals.tem_host, 3535,  verbose=True)
         self.cfg = ConfigurationClient(redis_host(), token=auth_token())
         self.metadata_notifier = MetadataNotifier(host = "noether")
-        self.standard_h5_recording = standard_h5_recording
+        # self.standard_h5_recording = standard_h5_recording
 
         self.reset_rotation_signal.connect(self.reset_rotation_button)
 
@@ -214,32 +215,32 @@ class RecordTask(Task):
 
             # Add H5 info and file finalization
             if self.writer is not None:
-                if self.standard_h5_recording:
-                    logging.info(" ******************** Adding Info to H5...")
+                # if self.standard_h5_recording:
+                #     logging.info(" ******************** Adding Info to H5...")
                     
-                    self.tem_action.temtools.trigger_addinfo_to_hdf5.emit()
-                    # os.rename(self.log_suffix + '.log', (self.cfg.data_dir/self.cfg.fname).with_suffix('.log'))
-                    formatted_filename= self.tem_action.file_operations.formatted_filename
-                    os.rename(self.log_suffix + '.log', formatted_filename.with_suffix('.log'))
+                #     self.tem_action.temtools.trigger_addinfo_to_hdf5.emit()
+                #     # os.rename(self.log_suffix + '.log', (self.cfg.data_dir/self.cfg.fname).with_suffix('.log'))
+                #     formatted_filename= self.tem_action.file_operations.formatted_filename
+                #     os.rename(self.log_suffix + '.log', formatted_filename.with_suffix('.log'))
                     
-                    logging.info(" ******************** Updating file_id in DB...")
-                    self.cfg.after_write()
-                    self.tem_action.file_operations.trigger_update_h5_index_box.emit()
-                else:
-                    time.sleep(0.1)
-                    logging.info(" ******************** Adding Info to H5 over Server...")
+                #     logging.info(" ******************** Updating file_id in DB...")
+                #     self.cfg.after_write()
+                #     self.tem_action.file_operations.trigger_update_h5_index_box.emit()
+                # else:
+                time.sleep(0.1)
+                logging.info(" ******************** Adding Info to H5 over Server...")
 
-                    send_with_retries(self.metadata_notifier.notify_metadata_update, 
-                                        self.tem_action.visualization_panel.formatted_filename, 
-                                        self.control.tem_status, 
-                                        self.cfg.beam_center, 
-                                        self.rotations_angles,
-                                        self.cfg.threshold,
-                                        retries=3, 
-                                        delay=0.1) 
-                    
-                    self.control.update_xtalinfo.emit('Processing', 'XDS')
-                    # self.control.update_xtalinfo.emit('Processing', 'DIALS')
+                send_with_retries(self.metadata_notifier.notify_metadata_update, 
+                                    self.tem_action.visualization_panel.formatted_filename, 
+                                    self.control.tem_status, 
+                                    self.cfg.beam_center, 
+                                    self.rotations_angles,
+                                    self.cfg.threshold,
+                                    retries=3, 
+                                    delay=0.1) 
+                
+                self.control.update_xtalinfo.emit('Processing', 'XDS')
+                # self.control.update_xtalinfo.emit('Processing', 'DIALS')
 
             # Same below is taken care of in FileOperations::toggle_hdf5Writer
             # in case self.writer is not None
@@ -269,13 +270,14 @@ class RecordTask(Task):
         finally:
             if logfile is not None:
                 logfile.close()  # Ensure the logfile is closed in case of any errors
-            if self.writer is not None:
-                if self.standard_h5_recording and self.tem_action.file_operations.streamWriterButton.started:
-                    self.writer[1]() # self.tem_action.file_operations.stop_H5_recording.emit()
-                else:
-                    self.reset_rotation_signal.emit()
-            else:
-                self.reset_rotation_signal.emit()
+            # if self.writer is not None:
+            #     if self.standard_h5_recording and self.tem_action.file_operations.streamWriterButton.started:
+            #         self.writer[1]() # self.tem_action.file_operations.stop_H5_recording.emit()
+            #     else:
+            #         self.reset_rotation_signal.emit()
+            # else:
+            #     self.reset_rotation_signal.emit()
+            self.reset_rotation_signal.emit()
         
         # self.make_xds_file(master_filepath,
         #                    os.path.join(sample_filepath, "INPUT.XDS"), # why not XDS.INP?
@@ -284,7 +286,7 @@ class RecordTask(Task):
     def reset_rotation_button(self):
         self.tem_action.tem_tasks.rotation_button.setText("Rotation")
         self.tem_action.tem_tasks.rotation_button.started = False
-        self.tem_action.file_operations.streamWriterButton.setEnabled(True)
+        # self.tem_action.file_operations.streamWriterButton.setEnabled(True)
          
     # def on_tem_receive(self):
     #     self.rotations_angles.append(

--- a/jungfrau_gui/ui_components/tem_controls/task/record_task.py
+++ b/jungfrau_gui/ui_components/tem_controls/task/record_task.py
@@ -231,18 +231,21 @@ class RecordTask(Task):
                 # else:
                 time.sleep(0.1)
                 logging.info(" ******************** Adding Info to H5 over Server...")
-
-                send_with_retries(self.metadata_notifier.notify_metadata_update, 
-                                    self.tem_action.visualization_panel.formatted_filename, 
-                                    self.control.tem_status, 
-                                    self.cfg.beam_center, 
-                                    self.rotations_angles,
-                                    self.cfg.threshold,
-                                    retries=3, 
-                                    delay=0.1) 
-                
-                self.control.update_xtalinfo.emit('Processing', 'XDS')
-                # self.control.update_xtalinfo.emit('Processing', 'DIALS')
+                try:
+                    send_with_retries(self.metadata_notifier.notify_metadata_update, 
+                                        self.tem_action.visualization_panel.formatted_filename, 
+                                        self.control.tem_status, 
+                                        self.cfg.beam_center, 
+                                        self.rotations_angles,
+                                        self.cfg.threshold,
+                                        retries=3, 
+                                        delay=0.1) 
+                    
+                    self.control.update_xtalinfo.emit('Processing', 'XDS')
+                    # self.control.update_xtalinfo.emit('Processing', 'DIALS')
+                except Exception as e:
+                        logging.error(f"Metadata Update Error: {e}")
+                        self.control.update_xtalinfo.emit('Metadata error', 'XDS')
 
             # Same below is taken care of in FileOperations::toggle_hdf5Writer
             # in case self.writer is not None

--- a/jungfrau_gui/ui_components/tem_controls/task/record_task.py
+++ b/jungfrau_gui/ui_components/tem_controls/task/record_task.py
@@ -38,13 +38,6 @@ class RecordTask(Task):
 
     def run(self):
         logging.debug("RecordTask::run()")
-        phi0 = self.client.GetTiltXAngle()
-        phi1 = self.end_angle
-
-        stage_rates = [10.0, 2.0, 1.0, 0.5]
-        phi_dot_idx = self.client.Getf1OverRateTxNum()
-
-        self.phi_dot = stage_rates[phi_dot_idx]
 
         if self.writer is not None:
             try:
@@ -56,6 +49,14 @@ class RecordTask(Task):
 
         try:
             logfile = None  # Initialize logfile to None
+            
+            phi0 = self.client.GetTiltXAngle()
+            phi1 = self.end_angle
+
+            stage_rates = [10.0, 2.0, 1.0, 0.5]
+            phi_dot_idx = self.client.Getf1OverRateTxNum()
+
+            self.phi_dot = stage_rates[phi_dot_idx]
 
             # Interrupting TEM Polling
             if self.tem_action.tem_tasks.connecttem_button.started:
@@ -271,6 +272,8 @@ class RecordTask(Task):
             if self.writer is not None:
                 if self.standard_h5_recording and self.tem_action.file_operations.streamWriterButton.started:
                     self.writer[1]() # self.tem_action.file_operations.stop_H5_recording.emit()
+                else:
+                    self.reset_rotation_signal.emit()
             else:
                 self.reset_rotation_signal.emit()
         

--- a/jungfrau_gui/ui_components/tem_controls/task/task_manager.py
+++ b/jungfrau_gui/ui_components/tem_controls/task/task_manager.py
@@ -203,22 +203,27 @@ class ControlWorker(QObject):
         if self.tem_action.tem_tasks.withwriter_checkbox.isChecked():
             self.file_operations.update_base_data_directory() # Update the GUI
             filename_suffix = self.cfg.data_dir / 'RotEDlog_test'
-            if self.tem_action.tem_tasks.JFJwriter_checkbox.isChecked():
-                task = RecordTask(
-                    self,
-                    end_angle,
-                    filename_suffix.as_posix(),
-                    writer_event = [self.visualization_panel.startCollection.clicked.emit, self.visualization_panel.stop_jfj_measurement.clicked.emit],
-                    standard_h5_recording=False
-                )
-            else:
-                task = RecordTask(
-                    self,
-                    end_angle,
-                    filename_suffix.as_posix(),
-                    writer_event = [self.file_operations.start_H5_recording.emit, self.file_operations.stop_H5_recording.emit],
-                    standard_h5_recording=True
-                )
+            # if self.tem_action.tem_tasks.JFJwriter_checkbox.isChecked():
+            #     task = RecordTask(
+            #         self,
+            #         end_angle,
+            #         filename_suffix.as_posix(),
+            #         writer_event = [self.visualization_panel.startCollection.clicked.emit, self.visualization_panel.stop_jfj_measurement.clicked.emit],
+            #         standard_h5_recording=False
+            #     )
+            # else:
+            #     task = RecordTask(
+            #         self,
+            #         end_angle,
+            #         filename_suffix.as_posix(),
+            #         writer_event = [self.file_operations.start_H5_recording.emit, self.file_operations.stop_H5_recording.emit],
+            #         standard_h5_recording=True
+            #     )
+            task = RecordTask(
+                self,
+                end_angle,
+                filename_suffix.as_posix(),
+                writer_event = [self.visualization_panel.startCollection.clicked.emit, self.visualization_panel.stop_jfj_measurement.clicked.emit])
         else:
             task = RecordTask(self, end_angle) #, filename_suffix.as_posix())
 

--- a/jungfrau_gui/ui_components/tem_controls/tem_action.py
+++ b/jungfrau_gui/ui_components/tem_controls/tem_action.py
@@ -372,7 +372,8 @@ class TEMAction(QObject):
 
     def go_listedposition(self):
         try:
-            position = self.control.client.GetStagePosition() # in nm
+            # position = self.control.client.GetStagePosition() # in nm
+            position = send_with_retries(self.control.client.GetStagePosition)
         except Exception as e:
             logging.error(f"Error: {e}")
             return
@@ -390,7 +391,8 @@ class TEMAction(QObject):
     @Slot(str, str)
     def add_listedposition(self, color='red', status='new'):
         try:
-            position = self.control.client.GetStagePosition()
+            # position = self.control.client.GetStagePosition()
+            position = send_with_retries(self.control.client.GetStagePosition)
         except Exception as e:
             logging.error(f"Error: {e}")
             return

--- a/jungfrau_gui/ui_components/tem_controls/tem_action.py
+++ b/jungfrau_gui/ui_components/tem_controls/tem_action.py
@@ -131,6 +131,7 @@ class TEMAction(QObject):
             self.tem_stagectrl.screen_button.setEnabled(enables)
         except AttributeError:
             pass 
+        self.tem_stagectrl.position_list.setEnabled(enables)
         self.tem_stagectrl.go_button.setEnabled(enables)
         self.tem_stagectrl.addpos_button.setEnabled(enables)
 

--- a/jungfrau_gui/ui_components/tem_controls/tem_action.py
+++ b/jungfrau_gui/ui_components/tem_controls/tem_action.py
@@ -374,7 +374,7 @@ class TEMAction(QObject):
         try:
             position = self.control.client.GetStagePosition() # in nm
         except Exception as e:
-            logging.error("Error: {e}")
+            logging.error(f"Error: {e}")
             return
         position_aim = np.array(self.tem_stagectrl.position_list.currentText().split()[1:-2], dtype=float) # in um
         dif_pos = position_aim[0]*1e3 - position[0], position_aim[1]*1e3 - position[1]
@@ -392,7 +392,7 @@ class TEMAction(QObject):
         try:
             position = self.control.client.GetStagePosition()
         except Exception as e:
-            logging.error("Error: {e}")
+            logging.error(f"Error: {e}")
             return
         new_id = self.tem_stagectrl.position_list.count() - 4
         self.tem_stagectrl.position_list.addItems([f"{new_id:3d}:{position[0]*1e-3:7.1f}{position[1]*1e-3:7.1f}{position[2]*1e-3:7.1f}, {status}"])

--- a/jungfrau_gui/ui_components/tem_controls/tem_action.py
+++ b/jungfrau_gui/ui_components/tem_controls/tem_action.py
@@ -302,8 +302,8 @@ class TEMAction(QObject):
             self.control.trigger_record.emit()
             self.tem_tasks.rotation_button.setText("Stop")
             self.tem_tasks.rotation_button.started = True
-            if self.tem_tasks.withwriter_checkbox.isChecked():
-                self.file_operations.streamWriterButton.setEnabled(False)
+            """ if self.tem_tasks.withwriter_checkbox.isChecked():
+                self.file_operations.streamWriterButton.setEnabled(False) """
         else:
             # In case of unwarranted interruption, to avoid button stuck in "Stop"
             if self.control.interruptRotation: 

--- a/jungfrau_gui/ui_components/tem_controls/tem_action.py
+++ b/jungfrau_gui/ui_components/tem_controls/tem_action.py
@@ -371,7 +371,11 @@ class TEMAction(QObject):
             # self.control.stop_task()
 
     def go_listedposition(self):
-        position = self.control.client.GetStagePosition() # in nm
+        try:
+            position = self.control.client.GetStagePosition() # in nm
+        except Exception as e:
+            logging.error("Error: {e}")
+            return
         position_aim = np.array(self.tem_stagectrl.position_list.currentText().split()[1:-2], dtype=float) # in um
         dif_pos = position_aim[0]*1e3 - position[0], position_aim[1]*1e3 - position[1]
         try:
@@ -385,7 +389,11 @@ class TEMAction(QObject):
 
     @Slot(str, str)
     def add_listedposition(self, color='red', status='new'):
-        position = self.control.client.GetStagePosition()
+        try:
+            position = self.control.client.GetStagePosition()
+        except Exception as e:
+            logging.error("Error: {e}")
+            return
         new_id = self.tem_stagectrl.position_list.count() - 4
         self.tem_stagectrl.position_list.addItems([f"{new_id:3d}:{position[0]*1e-3:7.1f}{position[1]*1e-3:7.1f}{position[2]*1e-3:7.1f}, {status}"])
         self.tem_stagectrl.gridarea.addItem(pg.ScatterPlotItem(x=[position[0]*1e-3], y=[position[1]*1e-3], brush=color))

--- a/jungfrau_gui/ui_components/tem_controls/tem_controls.py
+++ b/jungfrau_gui/ui_components/tem_controls/tem_controls.py
@@ -62,11 +62,12 @@ class TemControls(QGroupBox):
         self.voltage_spBx.setSuffix(" kV")
         self.voltage_spBx.setReadOnly(True)
 
-        self.label_beam_center = QLabel()
-        self.label_beam_center.setText("Beam center (px)")
+        self.label_Xo = QLabel()
+        self.label_Xo.setText("X_center (px)")
+        self.label_Yo = QLabel()
+        self.label_Yo.setText("Y_center (px)")
         
         self.beam_center_x = QSpinBox()
-        self.beam_center_x.setPrefix("X_center: ")
         self.beam_center_x.setValue(1)
         self.beam_center_x.setMaximum(globals.ncol)
         # self.beam_center_x.setReadOnly(True)
@@ -74,7 +75,6 @@ class TemControls(QGroupBox):
         self.beam_center_x.editingFinished.connect(self.update_beam_center_x)
         
         self.beam_center_y = QSpinBox()
-        self.beam_center_y.setPrefix("Y_center: ")
         self.beam_center_y.setValue(1)
         self.beam_center_y.setMaximum(globals.nrow)
         # self.beam_center_y.setReadOnly(True)

--- a/jungfrau_gui/ui_components/tem_controls/tem_controls.py
+++ b/jungfrau_gui/ui_components/tem_controls/tem_controls.py
@@ -60,7 +60,7 @@ class TemControls(QGroupBox):
         self.voltage_spBx.setMaximum(1000)
         self.voltage_spBx.setValue(200)
         self.voltage_spBx.setSuffix(" kV")
-        self.gauss_height_spBx.setReadOnly(True)
+        self.voltage_spBx.setReadOnly(True)
 
         self.label_beam_center = QLabel()
         self.label_beam_center.setText("Beam center (px)")

--- a/jungfrau_gui/ui_components/tem_controls/tem_controls.py
+++ b/jungfrau_gui/ui_components/tem_controls/tem_controls.py
@@ -55,7 +55,7 @@ class TemControls(QGroupBox):
         self.plotDialog = None
         
         self.label_voltage = QLabel()
-        self.label_voltage.setText("Voltage (HT)")
+        self.label_voltage.setText("Accelerating potential (HT)")
         self.voltage_spBx = QSpinBox()
         self.voltage_spBx.setMaximum(1000)
         self.voltage_spBx.setValue(200)

--- a/jungfrau_gui/ui_components/tem_controls/ui_tem_specific.py
+++ b/jungfrau_gui/ui_components/tem_controls/ui_tem_specific.py
@@ -1,6 +1,6 @@
 from PySide6.QtWidgets import (QGroupBox, QHBoxLayout, QVBoxLayout, QLabel, QLineEdit, QButtonGroup, 
                                QRadioButton, QPushButton, QCheckBox, QDoubleSpinBox, QSizePolicy, QComboBox,
-                               QSpinBox)
+                               QSpinBox, QWidget, QGridLayout)
 from PySide6.QtGui import QFont
 from ..toggle_button import ToggleButton
 from ..utils import create_horizontal_line_with_margin
@@ -10,6 +10,9 @@ from epoc import ConfigurationClient, auth_token, redis_host
 from ... import globals
 import pyqtgraph as pg
 import numpy as np
+
+font_big = QFont("Arial", 11)
+font_big.setBold(True)
 
 class TEMDetector(QGroupBox):
     def __init__(self):
@@ -41,12 +44,20 @@ class TEMDetector(QGroupBox):
 class TEMStageCtrl(QGroupBox):
     def __init__(self):
         super().__init__() #"Stage Status / Quick Moves"
+        self.setTitle("X/Y stage plot")  # optional
+        self.setCheckable(True)
+        self.setChecked(True)
+        # Connect QGroupBox toggled signal to a custom slot
+        self.toggled.connect(self.on_collapsed)
         self.initUI()
 
     def initUI(self):
         cfg = ConfigurationClient(redis_host(), token=auth_token())
 
         stage_ctrl_section = QVBoxLayout()
+        stage_ctrl_label = QLabel("Stage Control", self)
+        stage_ctrl_label.setFont(font_big)
+        stage_ctrl_section.addWidget(stage_ctrl_label)
 
         self.hbox_rot = QHBoxLayout()
         rot_label = QLabel("Rotation Speed:", self)
@@ -64,7 +75,7 @@ class TEMStageCtrl(QGroupBox):
         stage_ctrl_section.addLayout(self.hbox_rot)
         
         self.hbox_move = QHBoxLayout()
-        move_label = QLabel("Stage Ctrl:", self)
+        move_label = QLabel("Fast movement:", self)
         self.movestages = QButtonGroup()
         self.movex10ump = QPushButton('+10 µm', self)
         self.movex10umn = QPushButton('-10 µm', self)
@@ -88,7 +99,7 @@ class TEMStageCtrl(QGroupBox):
             i.setEnabled(False)
 
         self.hbox_magmode = QHBoxLayout()
-        mode_label = QLabel("Mag Mode:", self)
+        mode_label = QLabel("Magnification Mode:", self)
         self.mag_modes = QButtonGroup()
         self.mode_lowmag = QRadioButton('Low MAG', self)
         self.mode_mag =    QRadioButton('MAG', self)
@@ -133,23 +144,58 @@ class TEMStageCtrl(QGroupBox):
         self.hbox_gotopos.addWidget(self.go_button, 1)
         stage_ctrl_section.addLayout(self.hbox_gotopos)
         
-        self.plot_layout = QVBoxLayout()
+        # self.plot_layout = QVBoxLayout()
+        # self.grid_plot = pg.PlotWidget()
+        # self.plot_layout.addWidget(self.grid_plot)
+        # self.gridarea = self.grid_plot.plotItem
+        # radius = 3050 # in um
+        # x = radius * np.cos(np.linspace(0, 2*np.pi, 100))
+        # y = radius * np.sin(np.linspace(0, 2*np.pi, 100))
+        # self.gridarea.addItem(pg.PlotCurveItem(x=x, y=y))
+        # radius = 2350 # in um not very correct value!!
+        # x = radius * np.cos(np.linspace(0, 2*np.pi, 100))
+        # y = radius * np.sin(np.linspace(0, 2*np.pi, 100))
+        # self.gridarea.addItem(pg.PlotCurveItem(x=x, y=y))
+        # self.grid_plot.setAspectLocked()
+        # self.grid_plot.showGrid(x=True, y=True)
+        # stage_ctrl_section.addLayout(self.plot_layout)
+
+        # 1) Create a container widget to hold the plot
+        self.plot_container = QWidget()
+        self.plot_layout = QVBoxLayout(self.plot_container)
+
+        # 2) Create the PlotWidget
         self.grid_plot = pg.PlotWidget()
         self.plot_layout.addWidget(self.grid_plot)
+
+        # 3) Access the plotItem if needed
         self.gridarea = self.grid_plot.plotItem
-        radius = 3050 # in um
-        x = radius * np.cos(np.linspace(0, 2*np.pi, 100))
-        y = radius * np.sin(np.linspace(0, 2*np.pi, 100))
+
+        radius1 = 3050
+        x = radius1 * np.cos(np.linspace(0, 2*np.pi, 100))
+        y = radius1 * np.sin(np.linspace(0, 2*np.pi, 100))
         self.gridarea.addItem(pg.PlotCurveItem(x=x, y=y))
-        radius = 2350 # in um not very correct value!!
-        x = radius * np.cos(np.linspace(0, 2*np.pi, 100))
-        y = radius * np.sin(np.linspace(0, 2*np.pi, 100))
+
+        radius2 = 2350
+        x = radius2 * np.cos(np.linspace(0, 2*np.pi, 100))
+        y = radius2 * np.sin(np.linspace(0, 2*np.pi, 100))
         self.gridarea.addItem(pg.PlotCurveItem(x=x, y=y))
+
         self.grid_plot.setAspectLocked()
         self.grid_plot.showGrid(x=True, y=True)
-        stage_ctrl_section.addLayout(self.plot_layout)
+
+        # Add the plot_container (with its layout/plot) to the GroupBox layout
+        stage_ctrl_section.addWidget(self.plot_container)
 
         self.setLayout(stage_ctrl_section)
+
+    def on_collapsed(self, checked: bool):
+        """
+        Called whenever the QGroupBox is toggled.
+        If 'checked' is False, collapse (hide) the plot container.
+        If 'checked' is True, show it again.
+        """
+        self.plot_container.setVisible(checked)
 
 class TEMTasks(QGroupBox):
     def __init__(self, parent):
@@ -163,8 +209,6 @@ class TEMTasks(QGroupBox):
         CTN_group = QVBoxLayout()
         CTN_section = QHBoxLayout()
         CTN_label = QLabel("Connection to TEM", self)
-        font_big = QFont("Arial", 11)
-        font_big.setBold(True)
         CTN_label.setFont(font_big)
         self.connecttem_button = ToggleButton('Check TEM Connection', self)
         self.connecttem_button.setEnabled(True)
@@ -187,15 +231,15 @@ class TEMTasks(QGroupBox):
         BEAM_group = QVBoxLayout()
         BEAM_label = QLabel("Beam Sweep & Focus", self)
         BEAM_label.setFont(font_big)
-        self.btnGaussianFit = ToggleButton("Beam Gaussian Fit", self)
+        self.btnGaussianFit = ToggleButton("Gaussian Fit", self)
         self.btnGaussianFit.setEnabled(False)
-        self.beamAutofocus = ToggleButton('Beam Autofocus', self)
+        self.beamAutofocus = ToggleButton('Autofocus', self)
         self.beamAutofocus.setEnabled(False)
         self.popup_checkbox = self.parent.checkbox
         self.plotDialog = self.parent.plotDialog
 
         ROT_group = QVBoxLayout()
-        ROT_label = QLabel("Rotation & Stage Control", self)
+        ROT_label = QLabel("Rotation", self)
         ROT_label.setFont(font_big)
 
         ROT_section_1= QHBoxLayout()
@@ -211,7 +255,7 @@ class TEMTasks(QGroupBox):
         self.autoreset_checkbox = QCheckBox("Auto reset", self)
         self.autoreset_checkbox.setChecked(False)
 
-        ROT_section_2= QVBoxLayout()
+        ROT_section_2= QHBoxLayout()
 
         INPUT_layout = QHBoxLayout()
         input_start_angle_lb = QLabel("Start angle:", self) # current value
@@ -255,32 +299,28 @@ class TEMTasks(QGroupBox):
 
         BEAM_group.addWidget(BEAM_label)
         BEAM_group.addLayout(Voltage_layout)
-        BEAM_group.addWidget(self.btnGaussianFit)
-        BEAM_group.addWidget(self.beamAutofocus)
+        layout_Beam_buttons = QHBoxLayout()
+        layout_Beam_buttons.addWidget(self.btnGaussianFit)
+        layout_Beam_buttons.addWidget(self.beamAutofocus)
+        BEAM_group.addLayout(layout_Beam_buttons)
         BEAM_group.addWidget(self.popup_checkbox)
         
-        BeamFocus_layout = QVBoxLayout()
-        gauss_center_layout = QHBoxLayout()
-        gauss_center_layout.addWidget(self.parent.label_beam_center, 3)  
-        gauss_center_layout.addWidget(self.parent.beam_center_x, 2)
-        gauss_center_layout.addWidget(self.parent.beam_center_y, 2)
-        BeamFocus_layout.addLayout(gauss_center_layout)
-        gauss_H_layout = QHBoxLayout()
-        gauss_H_layout.addWidget(self.parent.label_gauss_height, 3)  
-        gauss_H_layout.addWidget(self.parent.gauss_height_spBx, 4)
-        BeamFocus_layout.addLayout(gauss_H_layout)
-        sigma_x_layout = QHBoxLayout()
-        sigma_x_layout.addWidget(self.parent.label_sigma_x, 3)  
-        sigma_x_layout.addWidget(self.parent.sigma_x_spBx, 4)         
-        BeamFocus_layout.addLayout(sigma_x_layout)
-        sigma_y_layout = QHBoxLayout()
-        sigma_y_layout.addWidget(self.parent.label_sigma_y, 3)  
-        sigma_y_layout.addWidget(self.parent.sigma_y_spBx, 4)         
-        BeamFocus_layout.addLayout(sigma_y_layout)        
-        rot_angle_layout = QHBoxLayout()
-        rot_angle_layout.addWidget(self.parent.label_rot_angle, 3)  
-        rot_angle_layout.addWidget(self.parent.angle_spBx, 4)         
-        BeamFocus_layout.addLayout(rot_angle_layout)
+        BeamFocus_layout = QGridLayout()
+
+        BeamFocus_layout.addWidget(self.parent.label_Xo          ,0,0)
+        BeamFocus_layout.addWidget(self.parent.beam_center_x,     0,1)
+        BeamFocus_layout.addWidget(self.parent.label_Yo          ,0,2)
+        BeamFocus_layout.addWidget(self.parent.beam_center_y,     0,3)
+
+        BeamFocus_layout.addWidget(self.parent.label_gauss_height,1,0)  
+        BeamFocus_layout.addWidget(self.parent.gauss_height_spBx, 1,1)
+        BeamFocus_layout.addWidget(self.parent.label_rot_angle,   1,2)  
+        BeamFocus_layout.addWidget(self.parent.angle_spBx,        1,3)
+
+        BeamFocus_layout.addWidget(self.parent.label_sigma_x,     2,0)  
+        BeamFocus_layout.addWidget(self.parent.sigma_x_spBx,      2,1)         
+        BeamFocus_layout.addWidget(self.parent.label_sigma_y,     2,2)  
+        BeamFocus_layout.addWidget(self.parent.sigma_y_spBx,      2,3)         
         
         BEAM_group.addLayout(BeamFocus_layout)
 
@@ -298,6 +338,7 @@ class TEMTasks(QGroupBox):
         ROT_section_1.addWidget(self.autoreset_checkbox)
         ROT_group.addLayout(ROT_section_1)
         ROT_section_2.addLayout(INPUT_layout)
+        ROT_section_2.addSpacing(30)
         ROT_section_2.addLayout(END_layout)
         ROT_group.addLayout(ROT_section_2)
         tasks_section.addLayout(ROT_group)
@@ -310,9 +351,6 @@ class XtalInfo(QGroupBox):
         self.initUI()
 
     def initUI(self):
-        font_big = QFont("Arial", 11)
-        font_big.setBold(True)
-
         xtal_section = QVBoxLayout()
         xtal_label = QLabel("Result of Processing", self)
         xtal_label.setFont(font_big)

--- a/jungfrau_gui/ui_components/tem_controls/ui_tem_specific.py
+++ b/jungfrau_gui/ui_components/tem_controls/ui_tem_specific.py
@@ -294,11 +294,12 @@ class TEMTasks(QGroupBox):
         tasks_section.addWidget(create_horizontal_line_with_margin(20))
 
         Voltage_layout = QHBoxLayout()
-        Voltage_layout.addWidget(self.parent.label_voltage, 3)  
-        Voltage_layout.addWidget(self.parent.voltage_spBx, 2)
+        Voltage_layout.addWidget(self.parent.label_voltage, 2)  
+        Voltage_layout.addWidget(self.parent.voltage_spBx,  2)
 
         BEAM_group.addWidget(BEAM_label)
         BEAM_group.addLayout(Voltage_layout)
+        BEAM_group.addSpacing(10)
         layout_Beam_buttons = QHBoxLayout()
         layout_Beam_buttons.addWidget(self.btnGaussianFit)
         layout_Beam_buttons.addWidget(self.beamAutofocus)

--- a/jungfrau_gui/ui_components/tem_controls/ui_tem_specific.py
+++ b/jungfrau_gui/ui_components/tem_controls/ui_tem_specific.py
@@ -72,6 +72,7 @@ class TEMStageCtrl(QGroupBox):
         self.rb_speeds.addButton(self.rb_speed_10, 0)
         self.rb_speeds.button(cfg.rotation_speed_idx).setChecked(True)
         self.hbox_rot.addWidget(rot_label, 1)
+        stage_ctrl_section.addSpacing(10)
         stage_ctrl_section.addLayout(self.hbox_rot)
         
         self.hbox_move = QHBoxLayout()
@@ -239,7 +240,7 @@ class TEMTasks(QGroupBox):
         self.plotDialog = self.parent.plotDialog
 
         ROT_group = QVBoxLayout()
-        ROT_label = QLabel("Rotation", self)
+        ROT_label = QLabel("Rotation/Record", self)
         ROT_label.setFont(font_big)
 
         ROT_section_1= QHBoxLayout()
@@ -249,8 +250,8 @@ class TEMTasks(QGroupBox):
         self.withwriter_checkbox.setChecked(False)
 
         # if globals.jfj:
-        self.JFJwriter_checkbox = QCheckBox("JFJ", self)
-        self.JFJwriter_checkbox.setChecked(False)
+        # self.JFJwriter_checkbox = QCheckBox("JFJ", self)
+        # self.JFJwriter_checkbox.setChecked(False)
         
         self.autoreset_checkbox = QCheckBox("Auto reset", self)
         self.autoreset_checkbox.setChecked(False)
@@ -267,6 +268,7 @@ class TEMTasks(QGroupBox):
         # self.input_start_angle.setValue("")
         self.input_start_angle.setReadOnly(True)
 
+        INPUT_layout.addSpacing(10)
         INPUT_layout.addWidget(input_start_angle_lb)
         INPUT_layout.addWidget(self.input_start_angle)
 
@@ -330,13 +332,14 @@ class TEMTasks(QGroupBox):
         tasks_section.addWidget(create_horizontal_line_with_margin(20))
 
         ROT_group.addWidget(ROT_label)
-        ROT_section_1.addWidget(self.rotation_button)
-        ROT_section_1.addWidget(self.withwriter_checkbox)
+        ROT_section_1.addWidget(self.rotation_button,     2)
+        ROT_section_1.addWidget(self.withwriter_checkbox, 1)
 
         # if globals.jfj:
-        ROT_section_1.addWidget(self.JFJwriter_checkbox)
+        # ROT_section_1.addWidget(self.JFJwriter_checkbox)
 
-        ROT_section_1.addWidget(self.autoreset_checkbox)
+        ROT_section_1.addWidget(self.autoreset_checkbox,  1)
+        ROT_group.addSpacing(10)
         ROT_group.addLayout(ROT_section_1)
         ROT_section_2.addLayout(INPUT_layout)
         ROT_section_2.addSpacing(30)

--- a/jungfrau_gui/ui_components/utils.py
+++ b/jungfrau_gui/ui_components/utils.py
@@ -2,7 +2,7 @@
 import numpy as np
 from PySide6.QtWidgets import (QVBoxLayout, QWidget, QFrame)
 
-def create_gaussian(size_x, size_y, sigma_x, sigma_y, theta):
+def create_gaussian(amplitude, size_x, size_y, sigma_x, sigma_y, theta):
     """
     Create a 2D Gaussian distribution tilted by an angle theta.
     
@@ -24,7 +24,7 @@ def create_gaussian(size_x, size_y, sigma_x, sigma_y, theta):
     b = -(np.sin(2*theta))/(4*sigma_x**2) + (np.sin(2*theta))/(4*sigma_y**2)
     c = (np.sin(theta)**2)/(2*sigma_x**2) + (np.cos(theta)**2)/(2*sigma_y**2)
     
-    gaussian = np.exp(-(a*x**2 + 2*b*x*y + c*y**2))
+    gaussian = amplitude * np.exp(-(a*x**2 + 2*b*x*y + c*y**2))
     return gaussian.astype(np.float32)
 
 def create_horizontal_line_with_margin(margin=10):

--- a/jungfrau_gui/ui_components/visualization_panel/visualization_panel.py
+++ b/jungfrau_gui/ui_components/visualization_panel/visualization_panel.py
@@ -979,7 +979,7 @@ class VisualizationPanel(QGroupBox):
             self.parent.timer.start()
             # if not globals.jfj:
             #     self.parent.file_operations.accumulate_button.setEnabled(True)
-            self.parent.file_operations.streamWriterButton.setEnabled(True)
+            """ self.parent.file_operations.streamWriterButton.setEnabled(True) """
         else:
             self.stream_view_button.setText("View Stream")
             self.parent.plot.setTitle("Stream stopped at the current Frame")
@@ -990,7 +990,7 @@ class VisualizationPanel(QGroupBox):
             # Disable buttons
             # if not globals.jfj:
             #     self.parent.file_operations.accumulate_button.setEnabled(False)
-            self.parent.file_operations.streamWriterButton.setEnabled(False)
+            """ self.parent.file_operations.streamWriterButton.setEnabled(False) """
             # Wait for thread to actually stop
             if self.thread_read is not None:
                 logging.info("** Read-thread forced to sleep **")

--- a/jungfrau_gui/ui_components/visualization_panel/visualization_panel.py
+++ b/jungfrau_gui/ui_components/visualization_panel/visualization_panel.py
@@ -115,17 +115,19 @@ class VisualizationPanel(QGroupBox):
         self.autoContrastBtn.setStyleSheet('background-color: green; color: white;')
         self.autoContrastBtn.clicked.connect(self.toggle_autoContrast)
         self.resetContrastBtn = QPushButton("Reset Contrast")
-        self.resetContrastBtn.clicked.connect(self.resetContrast)
+        self.resetContrastBtn.clicked.connect(lambda: self.set_contrast(self.cfg.viewer_cmin, self.cfg.viewer_cmax))
         
-        self.contrast_0_Btn = QPushButton("-100 - 100")
-        self.contrast_1_Btn = QPushButton("0 - 500")
-        self.contrast_2_Btn = QPushButton("0 - 1000")
-        self.contrast_3_Btn = QPushButton("0 - 1e5")
+        self.contrast_0_Btn = QPushButton("-50 - 50")
+        self.contrast_1_Btn = QPushButton("0 - 100")
+        self.contrast_2_Btn = QPushButton("0 - 500")
+        self.contrast_3_Btn = QPushButton("0 - 1000")
+        self.contrast_4_Btn = QPushButton("0 - 1e5")
 
-        self.contrast_0_Btn.clicked.connect(self.contrast_0)
-        self.contrast_1_Btn.clicked.connect(self.contrast_1)
-        self.contrast_2_Btn.clicked.connect(self.contrast_2)
-        self.contrast_3_Btn.clicked.connect(self.contrast_3)
+        self.contrast_0_Btn.clicked.connect(lambda: self.set_contrast(-50, 50))
+        self.contrast_1_Btn.clicked.connect(lambda: self.set_contrast(0, 100))
+        self.contrast_2_Btn.clicked.connect(lambda: self.set_contrast(0, 500))
+        self.contrast_3_Btn.clicked.connect(lambda: self.set_contrast(0, 1000))
+        self.contrast_4_Btn.clicked.connect(lambda: self.set_contrast(0, 100000))
 
         view_contrast_group = QVBoxLayout()
         view_contrast_label = QLabel("Streaming & Contrast")
@@ -133,14 +135,15 @@ class VisualizationPanel(QGroupBox):
         view_contrast_group.addWidget(view_contrast_label)
 
         grid_1 = QGridLayout()
-        grid_1.addWidget(self.stream_view_button, 0, 0, 2, 3)  # Span two rows two columns
-        grid_1.addWidget(self.autoContrastBtn, 0, 3)
-        grid_1.addWidget(self.resetContrastBtn, 1, 3)
+        grid_1.addWidget(self.stream_view_button, 0, 0, 2, 4)  # Span two rows two columns
+        grid_1.addWidget(self.autoContrastBtn, 0, 4)
+        grid_1.addWidget(self.resetContrastBtn, 1, 4)
 
         grid_1.addWidget(self.contrast_0_Btn, 2, 0, 1, 1 )
         grid_1.addWidget(self.contrast_1_Btn, 2, 1, 1, 1 )
         grid_1.addWidget(self.contrast_2_Btn, 2, 2, 1, 1 )
         grid_1.addWidget(self.contrast_3_Btn, 2, 3, 1, 1 )
+        grid_1.addWidget(self.contrast_4_Btn, 2, 4, 1, 1 )
  
         view_contrast_group.addLayout(grid_1)
         section_visual.addLayout(view_contrast_group)
@@ -895,40 +898,12 @@ class VisualizationPanel(QGroupBox):
         # Apply the modified LUT to the ImageItem
         self.parent.imageItem.setLookupTable(lut)
 
-    def resetContrast(self):
+    def set_contrast(self, lower, upper):
         self.parent.timer_contrast.stop()
         self.autoContrastBtn.started = False
         self.autoContrastBtn.setStyleSheet('background-color: green; color: white;')
         self.autoContrastBtn.setText('Apply Auto Contrast')
-        self.parent.histogram.setLevels(self.cfg.viewer_cmin, self.cfg.viewer_cmax)
-    
-    def contrast_0(self):
-        self.parent.timer_contrast.stop()
-        self.autoContrastBtn.started = False
-        self.autoContrastBtn.setStyleSheet('background-color: green; color: white;')
-        self.autoContrastBtn.setText('Apply Auto Contrast')
-        self.parent.histogram.setLevels(-50,50)
-    
-    def contrast_1(self):
-        self.parent.timer_contrast.stop()
-        self.autoContrastBtn.started = False
-        self.autoContrastBtn.setStyleSheet('background-color: green; color: white;')
-        self.autoContrastBtn.setText('Apply Auto Contrast')
-        self.parent.histogram.setLevels(0, 500)
-    
-    def contrast_2(self):
-        self.parent.timer_contrast.stop()
-        self.autoContrastBtn.started = False
-        self.autoContrastBtn.setStyleSheet('background-color: green; color: white;')
-        self.autoContrastBtn.setText('Apply Auto Contrast')
-        self.parent.histogram.setLevels(0, 1000)
-    
-    def contrast_3(self):
-        self.parent.timer_contrast.stop()
-        self.autoContrastBtn.started = False
-        self.autoContrastBtn.setStyleSheet('background-color: green; color: white;')
-        self.autoContrastBtn.setText('Apply Auto Contrast')
-        self.parent.histogram.setLevels(0, 100000) # '0-1e5'
+        self.parent.histogram.setLevels(lower, upper)
     
     def toggle_autoContrast(self):
         if not self.autoContrastBtn.started:

--- a/jungfrau_gui/ui_components/visualization_panel/visualization_panel.py
+++ b/jungfrau_gui/ui_components/visualization_panel/visualization_panel.py
@@ -133,9 +133,9 @@ class VisualizationPanel(QGroupBox):
         view_contrast_group.addWidget(view_contrast_label)
 
         grid_1 = QGridLayout()
-        grid_1.addWidget(self.stream_view_button, 0, 0, 2, 2)  # Span two rows two columns
-        grid_1.addWidget(self.autoContrastBtn, 0, 2)
-        grid_1.addWidget(self.resetContrastBtn, 1, 2)
+        grid_1.addWidget(self.stream_view_button, 0, 0, 2, 3)  # Span two rows two columns
+        grid_1.addWidget(self.autoContrastBtn, 0, 3)
+        grid_1.addWidget(self.resetContrastBtn, 1, 3)
 
         grid_1.addWidget(self.contrast_0_Btn, 2, 0, 1, 1 )
         grid_1.addWidget(self.contrast_1_Btn, 2, 1, 1, 1 )

--- a/jungfrau_gui/ui_main_window.py
+++ b/jungfrau_gui/ui_main_window.py
@@ -102,7 +102,7 @@ class ApplicationWindow(QMainWindow):
         self.roi.sigRegionChanged.connect(self.roiChanged)
 
         # Initial data (optional)
-        data = create_gaussian(globals.ncol, globals.nrow, 30, 15, np.deg2rad(35))
+        data = create_gaussian(1000, globals.ncol, globals.nrow, 30, 15, np.deg2rad(35))
         # data = np.random.rand(globals.nrow,globals.ncol).astype(globals.dtype)
         logging.debug(f"type(data) is {type(data[0,0])}")
         self.imageItem.setImage(data, autoRange = False, autoLevels = False, autoHistogramRange = False)

--- a/jungfrau_gui/ui_main_window.py
+++ b/jungfrau_gui/ui_main_window.py
@@ -227,9 +227,9 @@ class ApplicationWindow(QMainWindow):
                                         QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
             if reply == QMessageBox.Yes:
                 globals.exit_flag.value = True
-                if self.file_operations.streamWriter is not None:
+                """ if self.file_operations.streamWriter is not None:
                     if self.file_operations.streamWriter.write_process.is_alive():
-                        self.file_operations.streamWriter.stop()
+                        self.file_operations.streamWriter.stop() """
                 # if self.file_operations.frameAccumulator is not None:
                 #     if self.file_operations.frameAccumulator.accumulate_process.is_alive():
                 #         self.file_operations.frameAccumulator.accumulate_process.terminate()


### PR DESCRIPTION
- Update Usermanual

- Delete calls to old h5 plugin:
       1. delete ```Write Stream``` button
       2. delete JFJ checkbox
-> Data can only written with JFJ and saved on the server (noether)

- Define beamcenter as ```int``` in metadata
- Enhanced error handling during rotation/record tasks (data collection)
- Relocate ROI in the central beam area
- Redefine imageClickEvent only for TEMmode 
- Enhanced rebin() and getcenter() methods for XDS processing
- Add exception handling for Add/Go operations for Stage Position tracking 
      - multiple attempts for ```GetStagePositon``` query
      -  directly returns i case of failure