### PR TITLE
major bug-fixes

### DIFF
--- a/jungfrau_gui/ui_components/file_operations/file_operations.py
+++ b/jungfrau_gui/ui_components/file_operations/file_operations.py
@@ -323,15 +323,20 @@ class FileOperations(QGroupBox):
             if self.parent.tem_controls.tem_action.temConnector is not None: ## to be checked again
                 self.parent.tem_controls.tem_action.control.send_to_tem("#more", asynchronous = False)
                 logging.info(" ******************** Adding Info to H5 over Server...")
+                beam_property = {
+                    "beamcenter" : self.cfg.beam_center, 
+                    "sigma_width" : self.parent.tem_controls.tem_action.control.beam_sigmaxy,
+                    "illumination" : self.parent.tem_controls.tem_action.control.beam_intensity,
+                }                
                 try:
                     send_with_retries(self.metadata_notifier.notify_metadata_update, 
                                         self.parent.visualization_panel.formatted_filename, 
-                                        self.parent.tem_controls.tem_action.control.tem_status, #self.control.tem_status, 
-                                        self.cfg.beam_center, 
+                                        self.parent.tem_controls.tem_action.control.tem_status, 
+                                        beam_property,
                                         None, # self.rotations_angles,
                                         self.cfg.threshold,
                                         retries=3, 
-                                    delay=0.1) 
+                                        delay=0.1) 
                 except Exception as e:
                     logging.error(f"Metadata Update Error: {e}")
             logging.info(f'Snapshot duration end: {int(self.snapshot_spin.value())*1e-3} sec')

--- a/jungfrau_gui/ui_components/tem_controls/task/task_manager.py
+++ b/jungfrau_gui/ui_components/tem_controls/task/task_manager.py
@@ -219,8 +219,8 @@ class ControlWorker(QObject):
             time.sleep(0.1)
             self.tem_action.tem_tasks.btnGaussianFit.clicked.disconnect()
             
-        self.beam_sigmaxy = [self.tem_action.tem_controls.sigma_x_spBx.value(), 
-                             self.tem_action.tem_controls.sigma_y_spBx.value()]            
+        self.beam_sigmaxy = [self.tem_action.tem_controls.sigma_x_spBx.value(),
+                             self.tem_action.tem_controls.sigma_y_spBx.value()]
             
         if self.tem_action.tem_tasks.withwriter_checkbox.isChecked():
             self.file_operations.update_base_data_directory() # Update the GUI

--- a/jungfrau_gui/ui_components/tem_controls/tem_action.py
+++ b/jungfrau_gui/ui_components/tem_controls/tem_action.py
@@ -90,7 +90,7 @@ class TEMAction(QObject):
         self.tem_stagectrl.movex10ump.clicked.connect(lambda: self.control.trigger_movewithbacklash.emit(0,  10000, cfg_jf.others.backlash[0]))
         self.tem_stagectrl.movex10umn.clicked.connect(lambda: self.control.trigger_movewithbacklash.emit(1, -10000, cfg_jf.others.backlash[0]))
         self.tem_stagectrl.move10degp.clicked.connect(lambda: self.control.trigger_movewithbacklash.emit(6,  10, cfg_jf.others.backlash[3]))
-        self.tem_stagectrl.move10degp.clicked.connect(lambda: self.control.trigger_movewithbacklash.emit(7, -10, cfg_jf.others.backlash[3]))
+        self.tem_stagectrl.move10degn.clicked.connect(lambda: self.control.trigger_movewithbacklash.emit(7, -10, cfg_jf.others.backlash[3]))
 
         # Move X positive 10 micrometers
         #self.tem_stagectrl.movex10ump.clicked.connect(
@@ -232,6 +232,7 @@ class TEMAction(QObject):
             pass
         angle_x = self.control.tem_status["stage.GetPos"][3]
         if angle_x is not None: self.tem_tasks.input_start_angle.setValue(angle_x)
+        self.control.beam_sigmaxy = [self.tem_controls.sigma_x_spBx.value(), self.tem_controls.sigma_y_spBx.value()]
         
         # 1) Live query on both the current mode and the beam blank state
         Mag_idx = self.control.tem_status["eos.GetFunctionMode"][0] = self.control.client.GetFunctionMode()[0]

--- a/jungfrau_gui/ui_components/tem_controls/tem_action.py
+++ b/jungfrau_gui/ui_components/tem_controls/tem_action.py
@@ -112,7 +112,7 @@ class TEMAction(QObject):
         self.tem_stagectrl.move0deg.clicked.connect(
             lambda: threading.Thread(target=self.control.client.SetTiltXAngle, args=(0,)).start())
         self.tem_stagectrl.go_button.clicked.connect(self.go_listedposition)
-        self.tem_stagectrl.addpos_button.clicked.connect(self.add_listedposition)
+        self.tem_stagectrl.addpos_button.clicked.connect(lambda: self.add_listedposition())
         self.trigger_additem.connect(self.add_listedposition)
         self.trigger_processed_receiver.connect(self.inquire_processed_data)
         self.plot_listedposition()

--- a/jungfrau_gui/ui_components/tem_controls/tem_action.py
+++ b/jungfrau_gui/ui_components/tem_controls/tem_action.py
@@ -82,8 +82,8 @@ class TEMAction(QObject):
         except AttributeError:
             pass
         if globals.dev:
-            self.tem_detector.calc_e_incoming_button.clicked.connect(self.update_ecount)
-            self.tem_stagectrl.mapsnapshot_button.clicked.connect(self.take_snaphot)
+            self.tem_detector.calc_e_incoming_button.clicked.connect(lambda: self.update_ecount())
+            self.tem_stagectrl.mapsnapshot_button.clicked.connect(self.take_snapshot)
         
         self.control.updated.connect(self.on_tem_update)
 
@@ -118,8 +118,6 @@ class TEMAction(QObject):
         self.plot_listedposition()
         # self.trigger_getbeamintensity.connect(self.update_ecount)
         self.trigger_updateitem.connect(self.update_plotitem)
-        ## for debug
-        # self.tem_stagectrl.addpos_button.clicked.connect(lambda: self.update_plotitem())
 
     @Slot()
     def reconnectGaussianFit(self):
@@ -579,7 +577,7 @@ class TEMAction(QObject):
             self.tem_detector.e_incoming_display.setText(f'N/A')
             logging.warning(e)
 
-    def take_snaphot(self):
+    def take_snapshot(self):
         if self.control.tem_status["eos.GetFunctionMode"][0] == 4:
             logging.warning(f'Snaphot does not support Diff-mode at the moment!')
             return

--- a/jungfrau_gui/ui_components/tem_controls/toolbox/jfgui2_config.json
+++ b/jungfrau_gui/ui_components/tem_controls/toolbox/jfgui2_config.json
@@ -35,6 +35,11 @@
            "unit": "mm",
            "date_update": "03/12/2024"
          },
+         { "displayed": "20cm",
+           "calibrated": 290.0,
+           "unit": "mm",
+           "date_update": "01/01/1970"
+         },            
          { "displayed": "1cm",
            "calibrated": 1,
            "unit": "mm",


### PR DESCRIPTION
~**DRAFT**~
- add beam-info when saving snapshot too
- copy values of beam width for metadata
- correct typo for quick-rotation widget, snapshot widget
- dummy value for lut: if the value is not found in lut, the program stops. another error-capturer would be necessary
- restore lambda-description; *QPushButton without lambda passes a bool value to the function