### PR TITLE
Feature/correct off centered beam

### DIFF
--- a/jungfrau_gui/metadata_uploader/metadata_update_client.py
+++ b/jungfrau_gui/metadata_uploader/metadata_update_client.py
@@ -54,6 +54,7 @@ class MetadataNotifier:
         aperture_size_cl = cfg_jf.lut().cl_size(tem_status['apt.GetSize(1)'])
         aperture_size_sa = cfg_jf.lut().sa_size(tem_status['apt.GetSize(1)'])
         tem_status['rotation_axis'] = cfg_jf.lut().rotaxis_for_ht(tem_status["ht.GetHtValue"])
+        tem_status['optical_axis_center'] = cfg_jf.lut.optical_axis_center
 
         try:
             message = {

--- a/jungfrau_gui/metadata_uploader/metadata_update_server.py
+++ b/jungfrau_gui/metadata_uploader/metadata_update_server.py
@@ -97,7 +97,7 @@ class XDSparams:
                 self.xdsinp.append(keyw + ' ' + rem)
 
         if margin > 0:
-            self.xdsinp.append(f" UNTRUSTED_ELLIPSE= {orgx-margin:d} {orgx+margin:d} {orgy-margin:d} {orgy+margin:d}\n")                
+            self.xdsinp.append(f" UNTRUSTED_ELLIPSE= {orgx-margin:.0f} {orgx+margin:.0f} {orgy-margin:.0f} {orgy+margin:.0f}\n")
             
     def xdswrite(self, filepath="XDS.INP"):
         "write lines of keywords to XDS.INP in local directory"

--- a/jungfrau_gui/ui_components/tem_controls/toolbox/config.py
+++ b/jungfrau_gui/ui_components/tem_controls/toolbox/config.py
@@ -24,6 +24,7 @@ class lut:
     sa = parser['SA']
     positions = parser['position']
     ht_mag_specific = parser['ht_mag_specific']
+    optical_axis_center = parser['optical_axis_center']
 
     def __init__(self):
         self.array_data = np.array([list(d.values()) for d in self.distance])

--- a/jungfrau_gui/ui_components/tem_controls/toolbox/jfgui2_config.json
+++ b/jungfrau_gui/ui_components/tem_controls/toolbox/jfgui2_config.json
@@ -404,5 +404,6 @@
            "overlay_wh": [60, 60],
            "date_update": "16/3/2025"
          }
-]
+],
+  "optical_axis_center": [533.6, 540.3]
 }


### PR DESCRIPTION
Linked to https://github.com/epoc-ed/GUI/issues/157
- The optical axis (x=533.6/y=540.3) is stored in jfgui2_config.json to be managed with all other instrumental configuration values (will be managed in the database system in near future).
- '-p' option is connected to activate this function, as users should intentionally know the difference from the direct beam position.