### PR TITLE
removed errors by None

### DIFF
--- a/jungfrau_gui/metadata_uploader/metadata_update_client.py
+++ b/jungfrau_gui/metadata_uploader/metadata_update_client.py
@@ -54,7 +54,7 @@ class MetadataNotifier:
 
         detector_distance = cfg_jf.lut().interpolated_distance(tem_status['eos.GetMagValue_DIFF'][2], tem_status["ht.GetHtValue"]/1e3)
         aperture_size_cl = cfg_jf.lut().cl_size(tem_status['apt.GetSize(1)'])
-        aperture_size_sa = cfg_jf.lut().sa_size(tem_status['apt.GetSize(1)'])
+        aperture_size_sa = cfg_jf.lut().sa_size(tem_status['apt.GetSize(4)'])
         tem_status['rotation_axis'] = cfg_jf.lut().rotaxis_for_ht(tem_status["ht.GetHtValue"])
         tem_status['optical_axis_center'] = cfg_jf.lut.optical_axis_center
 


### PR DESCRIPTION
- 'None' in tem_status should be prevented because some of them are referred as metadata. This risk has not been apparent so far but revealed by the new error handling for timeout.
- This branch has worked for a short data-collection session, but please review and comment whether there are still potential errors.