### PR TITLE
remove the hard-coded path for xds

### DIFF
--- a/jungfrau_gui/metadata_uploader/metadata_update_server.py
+++ b/jungfrau_gui/metadata_uploader/metadata_update_server.py
@@ -487,7 +487,6 @@ class Hdf5MetadataUpdater:
                                           args=(filename, 
                                 process_dir + '/XDS/' + dataid,
                                 '/xtal/Integration/XDS/CCSA-templates/XDS-JF1M_JFJ_2024-12-10.INP',
-                                '/xtal/Integration/XDS/XDS-INTEL64_Linux_x86_64/xds_par', 
                                 beamcenter_refined, args.quiet, args.exoscillation, message["tem_status"]['gui_id'], ), daemon=True)
             xds_thread.start()
             # dials_thread = threading.Thread(target=self.run_dials, 
@@ -639,7 +638,7 @@ class Hdf5MetadataUpdater:
         except OSError as e:
             logging.error(f"Failed to update information in {filename}: {e}")
 
-    def run_xds(self, master_filepath, working_directory, xds_template_filepath, xds_exepath='xds_par', beamcenter=[515, 532], suppress=False, osc_measured=False, gui_id=999, pos_output=True, duration_sec=3):
+    def run_xds(self, master_filepath, working_directory, xds_template_filepath,beamcenter=[515, 532], suppress=False, osc_measured=False, gui_id=999, pos_output=True, duration_sec=3, xds_exepath='xds_par'):
         # self.socket.send_string("Processing with XDS")
         root = working_directory
         myxds = XDSparams(xdstempl=xds_template_filepath)


### PR DESCRIPTION
Removed the specific path defining the executable xds_par in the metadata-updater script (Users need to setup the execution setting for xds_par before launching the script).