### PR TITLE
use nominal distance when calibration fails

### DIFF
--- a/jungfrau_gui/ui_components/tem_controls/toolbox/config.py
+++ b/jungfrau_gui/ui_components/tem_controls/toolbox/config.py
@@ -50,7 +50,12 @@ class lut:
             return interpolated_distance[0]
         
     def calibrated_distance(self, key_search):
-        return self._lookup(self.distance, key_search, 'displayed', 'calibrated')
+        calibrated = self._lookup(self.distance, key_search, 'displayed', 'calibrated')
+        if calibrated != 0:
+            return calibrated
+        else:
+            logging.warning('Unregistered value. Nominal value returns instead!')
+            return self.distance
         
     def calibrated_magnification(self, key_search):
         return self._lookup(self.magnification, key_search, 'displayed', 'calibrated')


### PR DESCRIPTION
- When it is missing in the look-up table, returns not zero but the nominal distance
- Updating the lut should be another solution and will be provided by another branch in near future.