### PR TITLE
Feature/movable rectangle

### DIFF
--- a/jungfrau_gui/ui_components/tem_controls/toolbox/config.py
+++ b/jungfrau_gui/ui_components/tem_controls/toolbox/config.py
@@ -91,6 +91,8 @@ class lut:
         w, h = self._lookup(self.ht_mag_specific, ht_in_V, 'ht_voltage', 'overlay_wh', index=-1)
         item_rect = QGraphicsRectItem(QRectF(x, y, w, h))
         item_rect.setPen(pg.mkPen('r', width=2))
+        item_rect.setFlag(QGraphicsEllipseItem.ItemIsMovable)
+        item_rect.setFlag(QGraphicsEllipseItem.ItemIsSelectable)
 
         return item_circle, item_rect, item_common
     

--- a/jungfrau_gui/ui_components/tem_controls/toolbox/jfgui2_config.json
+++ b/jungfrau_gui/ui_components/tem_controls/toolbox/jfgui2_config.json
@@ -398,9 +398,9 @@
          { "ht_voltage": 200000,
            "magnification": 1200,
            "axis_xds": [0.604, -0.797, 0.0],
-           "overlay_xy": [482, 390],
+           "overlay_xy": [533, 340],
            "overlay_wh": [60, 60],
-           "date_update": "16/3/2025"
+           "date_update": "03/06/2025"
          },
          { "ht_voltage": 100000,
            "magnification": 20000,
@@ -412,9 +412,9 @@
          { "ht_voltage": 100000,
            "magnification": 1200,
            "axis_xds": [0.604, -0.797, 0.0],
-           "overlay_xy": [489, 372],
+           "overlay_xy": [487, 293],
            "overlay_wh": [60, 60],
-           "date_update": "16/3/2025"
+           "date_update": "22/05/2025"
          },
          { "ht_voltage": 80000,
            "magnification": 20000,
@@ -426,9 +426,9 @@
          { "ht_voltage": 80000,
            "magnification": 1200,
            "axis_xds": [0.604, -0.797, 0.0],
-           "overlay_xy": [516, 321],
+           "overlay_xy": [524, 230],
            "overlay_wh": [60, 60],
-           "date_update": "16/3/2025"
+           "date_update": "22/05/2025"
          }
 ],
   "optical_axis_center": [533.6, 540.3]


### PR DESCRIPTION
responding to the issue #202.
The starting position of the rectangle is updated for the status after filament-exchange (for all 80/100/200kV-cases).