### PR TITLE
reorder processes regarding SelectFunctionMode

### DIFF
--- a/jungfrau_gui/ui_components/tem_controls/task/task_manager.py
+++ b/jungfrau_gui/ui_components/tem_controls/task/task_manager.py
@@ -271,13 +271,13 @@ class ControlWorker(QObject):
                 # self.stop_task()
                 return           
                 
+        self._interupt_TEM_polling_and_pause_GF()
+
         if self.tem_status['eos.GetFunctionMode'][0] != 4:
             logging.warning('Switches ' + str(self.tem_status['eos.GetFunctionMode'][1]) + ' to DIFF mode')
             
             # Switching to Diffraction Mode
             self.client.SelectFunctionMode(4)
-
-        self._interupt_TEM_polling_and_pause_GF()
 
         self.beam_fitter = GaussianFitterMP()
 


### PR DESCRIPTION
~**DRAFT**~

Since both the polling routine and the if-clause in ```task_manager.py``` may call ```SelectFunctionMode```, interrupting polling **before** checking for mismatches can reduce the risk of interference.