### PR TITLE
fix: _full_fpath single source of truth  for file path

### DIFF
--- a/jungfrau_gui/ui_components/file_operations/file_operations.py
+++ b/jungfrau_gui/ui_components/file_operations/file_operations.py
@@ -364,7 +364,8 @@ class FileOperations(QGroupBox):
     #             }                
     #             try:
     #                 send_with_retries(self.metadata_notifier.notify_metadata_update, 
-    #                                     self.parent.visualization_panel.formatted_filename, 
+    # #                                    self.parent.visualization_panel.formatted_filename, 
+    #                                     self.parent.visualization_panel.full_fname, 
     #                                     self.parent.tem_controls.tem_action.control.tem_status, 
     #                                     beam_property,
     #                                     None, # self.rotations_angles,
@@ -460,7 +461,8 @@ class FileOperations(QGroupBox):
         try:
             send_with_retries(
                 self.metadata_notifier.notify_metadata_update, 
-                self.parent.visualization_panel.formatted_filename, 
+                # self.parent.visualization_panel.formatted_filename,
+                self.parent.visualization_panel.full_fname,
                 self.parent.tem_controls.tem_action.control.tem_status, 
                 beam_property,
                 None,  # self.rotations_angles,

--- a/jungfrau_gui/ui_components/file_operations/file_operations.py
+++ b/jungfrau_gui/ui_components/file_operations/file_operations.py
@@ -364,8 +364,7 @@ class FileOperations(QGroupBox):
     #             }                
     #             try:
     #                 send_with_retries(self.metadata_notifier.notify_metadata_update, 
-    # #                                    self.parent.visualization_panel.formatted_filename, 
-    #                                     self.parent.visualization_panel.full_fname, 
+    #                                     self.parent.visualization_panel.get_full_fname_path(), 
     #                                     self.parent.tem_controls.tem_action.control.tem_status, 
     #                                     beam_property,
     #                                     None, # self.rotations_angles,
@@ -461,8 +460,7 @@ class FileOperations(QGroupBox):
         try:
             send_with_retries(
                 self.metadata_notifier.notify_metadata_update, 
-                # self.parent.visualization_panel.formatted_filename,
-                self.parent.visualization_panel.full_fname,
+                self.parent.visualization_panel.get_full_fname_path(),
                 self.parent.tem_controls.tem_action.control.tem_status, 
                 beam_property,
                 None,  # self.rotations_angles,

--- a/jungfrau_gui/ui_components/file_operations/processresult_updater.py
+++ b/jungfrau_gui/ui_components/file_operations/processresult_updater.py
@@ -81,7 +81,7 @@ class ProcessedDataReceiver(QObject):
                 #     # ensure the socket is closed no matter what
         elif self.mode == 1: # load position list
             try:
-                search_path = self.parent.visualization_panel.full_fname.text()
+                search_path = self.parent.visualization_panel.get_full_fname_str()
                 socket.send_string(f"Session-metadata being inquired...: {search_path}")
                 result_json = socket.recv_string()
                 if 'not found' in result_json:
@@ -99,7 +99,7 @@ class ProcessedDataReceiver(QObject):
         elif self.mode == 2: # send position list
             try:
                 list_to_send = self.parent.tem_controls.tem_action.xtallist[1:]
-                list_to_send.append({'filename': self.parent.visualization_panel.full_fname.text()})
+                list_to_send.append({'filename': self.parent.visualization_panel.get_full_fname_str()})
                 filtered_list = [{k: v for k, v in d.items() if k not in {'gui_marker', 'gui_label'}} for d in list_to_send]
                 filtered_list = [item for item in filtered_list if not item.get('status') in ['recorded', 'processed']]
                 logging.debug(filtered_list)

--- a/jungfrau_gui/ui_components/tem_controls/task/record_task.py
+++ b/jungfrau_gui/ui_components/tem_controls/task/record_task.py
@@ -204,7 +204,8 @@ class RecordTask(Task):
                         "illumination" : self.control.beam_intensity,
                     }
                     send_with_retries(self.metadata_notifier.notify_metadata_update, 
-                                        self.tem_action.visualization_panel.formatted_filename, 
+                                        # self.tem_action.visualization_panel.formatted_filename, 
+                                        self.tem_action.visualization_panel.full_fname, 
                                         self.control.tem_status, 
                                         beam_property,
                                         self.rotations_angles,

--- a/jungfrau_gui/ui_components/tem_controls/task/record_task.py
+++ b/jungfrau_gui/ui_components/tem_controls/task/record_task.py
@@ -204,14 +204,13 @@ class RecordTask(Task):
                         "illumination" : self.control.beam_intensity,
                     }
                     send_with_retries(self.metadata_notifier.notify_metadata_update, 
-                                        # self.tem_action.visualization_panel.formatted_filename, 
-                                        self.tem_action.visualization_panel.full_fname, 
-                                        self.control.tem_status, 
-                                        beam_property,
-                                        self.rotations_angles,
-                                        self.cfg.threshold,
-                                        retries=3, 
-                                        delay=0.1) 
+                                      self.tem_action.visualization_panel.get_full_fname_path(), 
+                                      self.control.tem_status, 
+                                      beam_property,
+                                      self.rotations_angles,
+                                      self.cfg.threshold,
+                                      retries=3, 
+                                      delay=0.1) 
                     
                     self.file_operations.update_xtalinfo_signal.emit('Processing', 'XDS')
                     # self.file_operations.update_xtalinfo_signal.emit('Processing', 'DIALS')

--- a/jungfrau_gui/ui_components/visualization_panel/visualization_panel.py
+++ b/jungfrau_gui/ui_components/visualization_panel/visualization_panel.py
@@ -512,7 +512,9 @@ class VisualizationPanel(QGroupBox):
                     self.jfjoch_client.wait_until_idle()
                     
                     logging.warning(f"Starting to collect data...")
-                    self.formatted_filename = self.cfg.fpath
+                    # self.formatted_filename = self.cfg.fpath
+                    # self.full_fname = self.formatted_filename
+                    self.full_fname = self.cfg.fpath # update the filename as timestamp has probably changed
 
                     if globals.dev:
                         self.jfjoch_client.image_time_us = self.frame_summed.value() * 500 # i.e. 500 us per image for a 2kHz frame rate
@@ -523,7 +525,8 @@ class VisualizationPanel(QGroupBox):
                         self.parent.histogram.setLevels(prev_contrast[0] * self.frame_summed.value() / 100, prev_contrast[1] * self.frame_summed.value() / 100)
                     
                     self.jfjoch_client.start(n_images = self.jfjoch_client._lots_of_images,
-                                            fname = self.formatted_filename.as_posix(),
+                                            # fname = self.formatted_filename.as_posix(),
+                                            fname = self.full_fname.as_posix(),
                                             th = self.thresholdBox.value(),
                                             beam_x_pxl = self.cfg.beam_center[0],
                                             beam_y_pxl = self.cfg.beam_center[1],
@@ -620,7 +623,8 @@ class VisualizationPanel(QGroupBox):
             # Now proceed with the remaining code in "collect"
             logging.info("Measurement ended")
 
-            logging.info(f"Data has been saved in the following file:\n{self.formatted_filename.as_posix()}")
+            # logging.info(f"Data has been saved in the following file:\n{self.formatted_filename.as_posix()}")
+            logging.info(f"Data has been saved in the following file:\n{self.full_fname.as_posix()}")
             s = self.jfjoch_client.api_instance.statistics_data_collection_get()
             print(s)
 

--- a/jungfrau_gui/ui_components/visualization_panel/visualization_panel.py
+++ b/jungfrau_gui/ui_components/visualization_panel/visualization_panel.py
@@ -2,6 +2,7 @@ import time
 import logging
 import numpy as np
 import threading
+from pathlib import Path
 from PySide6.QtGui import QFont, QPalette
 from PySide6.QtCore import Qt, QThread, QMetaObject, Signal, QTimer, QThreadPool, QRunnable
 from PySide6.QtWidgets import ( QGroupBox, QVBoxLayout, QHBoxLayout, QLineEdit, 
@@ -231,7 +232,8 @@ class VisualizationPanel(QGroupBox):
         self.fname_label = QLabel("Path to recorded file", self)
         self.full_fname = QLineEdit(self)
         self.full_fname.setReadOnly(True)
-        self.full_fname.setText(self.cfg.fpath.as_posix())
+        self._full_fpath = self.cfg.fpath   # single source of truth for the path
+        self.full_fname.setText(self._full_fpath.as_posix())
 
         hbox_layout = QHBoxLayout()
         hbox_layout.addWidget(self.fname_label)
@@ -287,6 +289,18 @@ class VisualizationPanel(QGroupBox):
         section_visual.addStretch()
         self.setLayout(section_visual)
 
+    def update_full_fname_from_cfg(self):
+        self._full_fpath = self.cfg.fpath
+        self.full_fname.setText(self._full_fpath.as_posix())
+
+    def get_full_fname_str(self) -> str:
+        if not self._full_fpath:
+            return "<no filename set>"
+        return self._full_fpath.as_posix()
+
+    def get_full_fname_path(self) -> Path | None:
+        return self._full_fpath
+    
     """ ***************************************************** """
     """ Methods for the Jungfraujoch receiver (FPGA Solution) """
     """ ***************************************************** """
@@ -512,9 +526,9 @@ class VisualizationPanel(QGroupBox):
                     self.jfjoch_client.wait_until_idle()
                     
                     logging.warning(f"Starting to collect data...")
-                    # self.formatted_filename = self.cfg.fpath
-                    # self.full_fname = self.formatted_filename
-                    self.full_fname = self.cfg.fpath # update the filename as timestamp has probably changed
+                    self.update_full_fname_from_cfg()
+                    # self._full_fpath = self.cfg.fpath # update the filename as timestamp has probably changed
+                    # self.full_fname.setText(self._full_fpath.as_posix()) # update the GUI widget
 
                     if globals.dev:
                         self.jfjoch_client.image_time_us = self.frame_summed.value() * 500 # i.e. 500 us per image for a 2kHz frame rate
@@ -525,8 +539,7 @@ class VisualizationPanel(QGroupBox):
                         self.parent.histogram.setLevels(prev_contrast[0] * self.frame_summed.value() / 100, prev_contrast[1] * self.frame_summed.value() / 100)
                     
                     self.jfjoch_client.start(n_images = self.jfjoch_client._lots_of_images,
-                                            # fname = self.formatted_filename.as_posix(),
-                                            fname = self.full_fname.as_posix(),
+                                            fname = self.get_full_fname_str(),
                                             th = self.thresholdBox.value(),
                                             beam_x_pxl = self.cfg.beam_center[0],
                                             beam_y_pxl = self.cfg.beam_center[1],
@@ -623,8 +636,7 @@ class VisualizationPanel(QGroupBox):
             # Now proceed with the remaining code in "collect"
             logging.info("Measurement ended")
 
-            # logging.info(f"Data has been saved in the following file:\n{self.formatted_filename.as_posix()}")
-            logging.info(f"Data has been saved in the following file:\n{self.full_fname.as_posix()}")
+            logging.info(f"Data has been saved in the following file:\n{self.get_full_fname_str()}")
             s = self.jfjoch_client.api_instance.statistics_data_collection_get()
             print(s)
 


### PR DESCRIPTION
- eliminate the variable ```formatted_filename```
- only keep ```full_fname``` up-to-date and use it for data naming, metadata updating / postprocessing and in the UI display.
- TODO: test @ TEM before merge